### PR TITLE
Fixed image path for app store image in mobile badges

### DIFF
--- a/web-components/src/components/mobile-badges/mobile-badges.ts
+++ b/web-components/src/components/mobile-badges/mobile-badges.ts
@@ -260,9 +260,9 @@ export class MobileBadges extends LitElement {
    */
   getIosAppIconPath(language: string): string {
     if (language === "en") {
-      return "/appstore/black/appstore_UK.svg"
+      return "appstore/black/appstore_UK.svg"
     }
-    return `/appstore/black/appstore_${language.toLocaleUpperCase()}.svg`
+    return `appstore/black/appstore_${language.toLocaleUpperCase()}.svg`
   }
 
   /**


### PR DESCRIPTION
### What
Fixed app store path. Extra forward slash was coming.
Wrong path: /assets/images//appstore/black/appstore_UK.svg
Correct path: /assets/images/appstore/black/appstore_UK.svg

### Fixes bug(s)
- https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/160

### Part of 
- https://github.com/openfoodfacts/openfoodfacts-explorer/pull/537
