### PR TITLE
refactor: Introduce dynamic textColor support for reusability across pages

### DIFF
--- a/web-components/src/components/mobile-badges/mobile-badges.ts
+++ b/web-components/src/components/mobile-badges/mobile-badges.ts
@@ -13,18 +13,9 @@ export type Badge = {
   errorHandler?: (event: Event) => void
 }
 
-/**
- * Mobile Badges
- * @element mobile-badges
- * A web component that displays mobile app badges for downloading the Open Food Facts app.
- * It includes badges for Google Play, F-Droid, APK, and the Apple App Store.
- */
 @customElement("mobile-badges")
 @localized()
 export class MobileBadges extends LitElement {
-  /**
-   * Styles for the component.
-   */
   static override styles = css`
     #install_the_app_block {
       display: flex;
@@ -33,6 +24,7 @@ export class MobileBadges extends LitElement {
       flex-wrap: wrap;
       gap: 2rem;
     }
+
     #footer_install_the_app {
       font-family: "Public Sans", Helvetica, Roboto, Arial, sans-serif;
       font-weight: 550;
@@ -40,7 +32,9 @@ export class MobileBadges extends LitElement {
       line-height: 30px;
       text-transform: uppercase;
       margin-bottom: 8px;
+      color: var(--badge-text-color, #000); /* ← color controlled via CSS variable */
     }
+
     #footer_scan {
       font-family: "Public Sans", Helvetica, Roboto, Arial, sans-serif;
       font-style: normal;
@@ -50,9 +44,11 @@ export class MobileBadges extends LitElement {
       display: flex;
       align-items: center;
       text-align: center;
-      color: #000;
+      color: var(--badge-text-color, #000); /* ← color controlled via CSS variable */
       max-width: 420px;
     }
+
+    /* Responsive styles */
     @media (max-width: 480px) {
       #footer_install_the_app {
         font-size: 20px;
@@ -63,6 +59,7 @@ export class MobileBadges extends LitElement {
         line-height: 22px;
       }
     }
+
     @media (min-width: 768px) {
       #footer_install_the_app {
         font-size: 28px;
@@ -73,6 +70,7 @@ export class MobileBadges extends LitElement {
         line-height: 30px;
       }
     }
+
     @media (min-width: 1024px) {
       #footer_install_the_app {
         font-size: 30px;
@@ -83,6 +81,7 @@ export class MobileBadges extends LitElement {
         line-height: 32px;
       }
     }
+
     .everyday {
       transform: rotate(2.5deg);
       background-color: #0064c8;
@@ -94,6 +93,7 @@ export class MobileBadges extends LitElement {
       text-transform: uppercase;
       display: inline-block;
     }
+
     .foods {
       transform: rotate(-3deg);
       background-color: #ff8714;
@@ -105,52 +105,29 @@ export class MobileBadges extends LitElement {
       text-transform: uppercase;
       display: inline-block;
     }
+
     .no-text-decoration {
       text-decoration: none;
     }
+
     .badge-container {
       display: grid;
-      gap: 0.2rem; /* Reduced horizontal gap */
+      gap: 0.2rem;
       grid-template-columns: repeat(2, 1fr);
     }
-    @media (min-width: 768px) {
-      .badge-container {
-        grid-template-columns: repeat(4, 1fr);
-      }
-    }
-    .responsive-container {
-      flex-direction: column;
-      text-align: center;
-    }
+
     @media (min-width: 768px) {
       .badge-container {
         display: flex;
         justify-content: center;
       }
     }
+
     @media (max-width: 480px) {
       .badge-container {
         grid-template-columns: 1fr;
         gap: 0.5rem;
       }
-      .responsive-container {
-        flex-direction: column;
-        text-align: center;
-      }
-      .responsive-image {
-        margin-bottom: 1rem;
-      }
-      .responsive-text {
-        margin-top: 0.5rem;
-      }
-    }
-    #fdroid_badge {
-      transform: scale(1.1);
-      height: 50px;
-      margin-top: -4px;
-    }
-    #playstore_badge {
-      height: 45px;
     }
 
     .logo-container {
@@ -160,104 +137,55 @@ export class MobileBadges extends LitElement {
       max-width: 720px;
       gap: 2rem;
       flex-wrap: wrap;
+      flex-direction: column;
+      text-align: center;
+    }
+
+    #fdroid_badge {
+      transform: scale(1.1);
+      height: 50px;
+      margin-top: -4px;
+    }
+
+    #playstore_badge {
+      height: 45px;
     }
   `
 
-  /**
-   * Controls visibility of Google Play Store badge
-   * @type {boolean}
-   */
-  @property({ type: Boolean, attribute: "hide-play-store" })
-  hidePlayStore = false
+  @property({ type: Boolean, attribute: "hide-play-store" }) hidePlayStore = false
+  @property({ type: Boolean, attribute: "hide-f-droid" }) hideFDroid = false
+  @property({ type: Boolean, attribute: "hide-apk" }) hideApk = false
+  @property({ type: Boolean, attribute: "hide-app-store" }) hideAppStore = false
+  @property({ type: Boolean, attribute: "hide-image" }) hideImage = false
 
-  /**
-   * Controls visibility of F-Droid badge
-   * @type {boolean}
-   */
-  @property({ type: Boolean, attribute: "hide-f-droid" })
-  hideFDroid = false
+  // ✅ NEW: Add color property to allow passing text color from outside (like Svelte)
+  @property({ type: String }) color: string = "#000"
 
-  /**
-   * Controls visibility of APK download badge
-   * @type {boolean}
-   */
-  @property({ type: Boolean, attribute: "hide-apk" })
-  hideApk = false
-
-  /**
-   * Controls visibility of App Store badge
-   * @type {boolean}
-   */
-  @property({ type: Boolean, attribute: "hide-app-store" })
-  hideAppStore = false
-
-  /**
-   * Controls visibility of App Store badge
-   * @type {boolean}
-   */
-  @property({ type: Boolean, attribute: "hide-image" })
-  hideImage = false
-
-  /**
-   * Link to the F-Droid app page.
-   */
   @state()
   fDroidAppLink = "https://f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
 
-  /**
-   * Generates the URL suffix for Android app links.
-   * @param language - The language code.
-   * @param campaign - The campaign identifier.
-   * @returns The URL suffix with UTM parameters.
-   */
   private getAndroidUrlSuffix(language: string, campaign: string): string {
     return `?utm_source=off&utf_medium=web&utm_campaign=${campaign}_${language}`
   }
 
-  /**
-   * Generates the Google Play Store link for the app.
-   * @param language - The language code.
-   * @returns The Google Play Store link.
-   */
   getAndroidAppLink(language: string): string {
     const baseURI = `https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=${language}`
     return `${baseURI}${this.getAndroidUrlSuffix(language, "install_the_app_android_footer")}`
   }
 
-  /**
-   * Generates the APK download link for the app.
-   * @param language - The language code.
-   * @returns The APK download link.
-   */
   getAndroidApkAppLink(language: string): string {
     const baseURI = "https://github.com/openfoodfacts/smooth-app/releases/latest"
     return `${baseURI}${this.getAndroidUrlSuffix(language, "install_the_app_apk_footer")}`
   }
 
-  /**
-   * Generates the path to the Google Play Store badge icon.
-   * @param language - The language code.
-   * @returns The path to the badge icon.
-   */
   getAndroidAppIconPath(language: string): string {
     return `https://play.google.com/intl/en_us/badges/static/images/badges/${language}_badge_web_generic.png`
   }
 
-  /**
-   * Generates the path to the F-Droid badge icon.
-   * @param language - The language code.
-   * @returns The path to the badge icon.
-   */
   getFDroidAppIconPath(language: string): string {
     return `https://fdroid.gitlab.io/artwork/badge/get-it-on-${language}.png`
   }
 
-  /**
-   * Generates the path to the Apple App Store badge icon.
-   * Note: This code does not handle the US locale specifically.
-   * @param language - The language code.
-   * @returns The path to the badge icon.
-   */
   getIosAppIconPath(language: string): string {
     if (language === "en") {
       return "appstore/black/appstore_UK.svg"
@@ -265,26 +193,12 @@ export class MobileBadges extends LitElement {
     return `appstore/black/appstore_${language.toLocaleUpperCase()}.svg`
   }
 
-  /**
-   * Generates the Apple App Store link for the app.
-   * @param language - The language code.
-   * @returns The Apple App Store link.
-   */
   getIosAppLink(language: string): string {
     const baseURI =
       "https://apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web"
     return `${baseURI}&utm_campaign=install_the_app_ios_footer_${language}`
   }
 
-  /**
-   * Generates the HTML for a badge link.
-   * @param href - The URL for the badge link.
-   * @param src - The source of the badge image.
-   * @param alt - The alt text for the badge image.
-   * @param id - The id for the badge image.
-   * @param errorHandler - The error handler for the image.
-   * @returns The HTML template for the badge link.
-   */
   private generateBadgeLink(
     href: string,
     src: string,
@@ -307,10 +221,6 @@ export class MobileBadges extends LitElement {
     `
   }
 
-  /**
-   * Filters the badges based on the hide properties.
-   * @returns The filtered list of badges.
-   **/
   getFilteredBadges(): Badge[] {
     const language = getLocale()
     const badges: Badge[] = [
@@ -355,21 +265,15 @@ export class MobileBadges extends LitElement {
         },
       },
     ]
-
-    const filteredBadges = badges.filter((badge) => badge.hide == false)
-    return filteredBadges
+    return badges.filter((badge) => !badge.hide)
   }
 
-  /**
-   * Renders the image if hideImage is false
-   * @returns The image HTML or nothing if hideImage is true.
-   **/
   renderImage() {
-    if (this.hideImage) {
-      return nothing
-    }
+    if (this.hideImage) return nothing
+
     return html`
-      <div class="logo-container">
+      <div class="logo-container" style="--badge-text-color: ${this.color};"> 
+        <!-- ✅ Set color dynamically using CSS variable -->
         <img
           class="responsive-image"
           src="${getImageUrl("app-icon-in-the-clouds.svg")}"
@@ -378,36 +282,32 @@ export class MobileBadges extends LitElement {
         />
         <div id="footer_scan" style="display:block">
           <div id="footer_install_the_app">${msg("Install the app!")}</div>
-          <!-- TODO find fix to add text between span for translations ex for fr : "Scannez vos <span class="foods">aliments</span> de votre <span class="everyday">quotidien</span>" -->
-          ${msg(
-            html`Scan your <span class="everyday">everyday</span> <span class="foods">foods</span>`
-          )}
+          ${msg(html`Scan your <span class="everyday">everyday</span> <span class="foods">foods</span>`)}
         </div>
       </div>
     `
   }
 
-  /**
-   * Renders the badges if there are any filtered badges
-   * @returns The badges HTML or nothing if there are no filtered badges.
-   **/
   renderBadges() {
     const filteredBadges = this.getFilteredBadges()
-
-    return html` ${filteredBadges.length > 0
-      ? html`
-          <div class="badge-container ">
-            ${filteredBadges.map((badge) =>
-              this.generateBadgeLink(badge.href, badge.src, badge.alt, badge.id, badge.errorHandler)
-            )}
-          </div>
-        `
-      : ""}`
+    return html`
+      ${filteredBadges.length > 0
+        ? html`
+            <div class="badge-container">
+              ${filteredBadges.map((badge) =>
+                this.generateBadgeLink(badge.href, badge.src, badge.alt, badge.id, badge.errorHandler)
+              )}
+            </div>
+          `
+        : ""}
+    `
   }
 
   override render() {
     return html`
-      <div class="" id="install_the_app_block">${this.renderImage()} ${this.renderBadges()}</div>
+      <div id="install_the_app_block">
+        ${this.renderImage()} ${this.renderBadges()}
+      </div>
     `
   }
 }

--- a/web-components/src/components/mobile-badges/mobile-badges.ts
+++ b/web-components/src/components/mobile-badges/mobile-badges.ts
@@ -162,6 +162,11 @@ export class MobileBadges extends LitElement {
       flex-wrap: wrap;
     }
   `
+  /**
+   * It helps to set color of the text in other documents
+   */
+  @property({ type: String }) textColor = "#212121";
+
 
   /**
    * Controls visibility of Google Play Store badge
@@ -376,7 +381,7 @@ export class MobileBadges extends LitElement {
           alt="The Open Food Facts logo in the cloud"
           style="height:120px"
         />
-        <div id="footer_scan" style="display:block">
+        <div id="footer_scan" style="display: block; color: ${this.textColor};">
           <div id="footer_install_the_app">${msg("Install the app!")}</div>
           <!-- TODO find fix to add text between span for translations ex for fr : "Scannez vos <span class="foods">aliments</span> de votre <span class="everyday">quotidien</span>" -->
           ${msg(

--- a/web-components/src/components/mobile-badges/mobile-badges.ts
+++ b/web-components/src/components/mobile-badges/mobile-badges.ts
@@ -13,9 +13,18 @@ export type Badge = {
   errorHandler?: (event: Event) => void
 }
 
+/**
+ * Mobile Badges
+ * @element mobile-badges
+ * A web component that displays mobile app badges for downloading the Open Food Facts app.
+ * It includes badges for Google Play, F-Droid, APK, and the Apple App Store.
+ */
 @customElement("mobile-badges")
 @localized()
 export class MobileBadges extends LitElement {
+  /**
+   * Styles for the component.
+   */
   static override styles = css`
     #install_the_app_block {
       display: flex;
@@ -24,7 +33,6 @@ export class MobileBadges extends LitElement {
       flex-wrap: wrap;
       gap: 2rem;
     }
-
     #footer_install_the_app {
       font-family: "Public Sans", Helvetica, Roboto, Arial, sans-serif;
       font-weight: 550;
@@ -32,9 +40,7 @@ export class MobileBadges extends LitElement {
       line-height: 30px;
       text-transform: uppercase;
       margin-bottom: 8px;
-      color: var(--badge-text-color, #000); /* ← color controlled via CSS variable */
     }
-
     #footer_scan {
       font-family: "Public Sans", Helvetica, Roboto, Arial, sans-serif;
       font-style: normal;
@@ -44,11 +50,9 @@ export class MobileBadges extends LitElement {
       display: flex;
       align-items: center;
       text-align: center;
-      color: var(--badge-text-color, #000); /* ← color controlled via CSS variable */
+      color: #000;
       max-width: 420px;
     }
-
-    /* Responsive styles */
     @media (max-width: 480px) {
       #footer_install_the_app {
         font-size: 20px;
@@ -59,7 +63,6 @@ export class MobileBadges extends LitElement {
         line-height: 22px;
       }
     }
-
     @media (min-width: 768px) {
       #footer_install_the_app {
         font-size: 28px;
@@ -70,7 +73,6 @@ export class MobileBadges extends LitElement {
         line-height: 30px;
       }
     }
-
     @media (min-width: 1024px) {
       #footer_install_the_app {
         font-size: 30px;
@@ -81,7 +83,6 @@ export class MobileBadges extends LitElement {
         line-height: 32px;
       }
     }
-
     .everyday {
       transform: rotate(2.5deg);
       background-color: #0064c8;
@@ -93,7 +94,6 @@ export class MobileBadges extends LitElement {
       text-transform: uppercase;
       display: inline-block;
     }
-
     .foods {
       transform: rotate(-3deg);
       background-color: #ff8714;
@@ -105,29 +105,52 @@ export class MobileBadges extends LitElement {
       text-transform: uppercase;
       display: inline-block;
     }
-
     .no-text-decoration {
       text-decoration: none;
     }
-
     .badge-container {
       display: grid;
-      gap: 0.2rem;
+      gap: 0.2rem; /* Reduced horizontal gap */
       grid-template-columns: repeat(2, 1fr);
     }
-
+    @media (min-width: 768px) {
+      .badge-container {
+        grid-template-columns: repeat(4, 1fr);
+      }
+    }
+    .responsive-container {
+      flex-direction: column;
+      text-align: center;
+    }
     @media (min-width: 768px) {
       .badge-container {
         display: flex;
         justify-content: center;
       }
     }
-
     @media (max-width: 480px) {
       .badge-container {
         grid-template-columns: 1fr;
         gap: 0.5rem;
       }
+      .responsive-container {
+        flex-direction: column;
+        text-align: center;
+      }
+      .responsive-image {
+        margin-bottom: 1rem;
+      }
+      .responsive-text {
+        margin-top: 0.5rem;
+      }
+    }
+    #fdroid_badge {
+      transform: scale(1.1);
+      height: 50px;
+      margin-top: -4px;
+    }
+    #playstore_badge {
+      height: 45px;
     }
 
     .logo-container {
@@ -137,55 +160,104 @@ export class MobileBadges extends LitElement {
       max-width: 720px;
       gap: 2rem;
       flex-wrap: wrap;
-      flex-direction: column;
-      text-align: center;
-    }
-
-    #fdroid_badge {
-      transform: scale(1.1);
-      height: 50px;
-      margin-top: -4px;
-    }
-
-    #playstore_badge {
-      height: 45px;
     }
   `
 
-  @property({ type: Boolean, attribute: "hide-play-store" }) hidePlayStore = false
-  @property({ type: Boolean, attribute: "hide-f-droid" }) hideFDroid = false
-  @property({ type: Boolean, attribute: "hide-apk" }) hideApk = false
-  @property({ type: Boolean, attribute: "hide-app-store" }) hideAppStore = false
-  @property({ type: Boolean, attribute: "hide-image" }) hideImage = false
+  /**
+   * Controls visibility of Google Play Store badge
+   * @type {boolean}
+   */
+  @property({ type: Boolean, attribute: "hide-play-store" })
+  hidePlayStore = false
 
-  // ✅ NEW: Add color property to allow passing text color from outside (like Svelte)
-  @property({ type: String }) color: string = "#000"
+  /**
+   * Controls visibility of F-Droid badge
+   * @type {boolean}
+   */
+  @property({ type: Boolean, attribute: "hide-f-droid" })
+  hideFDroid = false
 
+  /**
+   * Controls visibility of APK download badge
+   * @type {boolean}
+   */
+  @property({ type: Boolean, attribute: "hide-apk" })
+  hideApk = false
+
+  /**
+   * Controls visibility of App Store badge
+   * @type {boolean}
+   */
+  @property({ type: Boolean, attribute: "hide-app-store" })
+  hideAppStore = false
+
+  /**
+   * Controls visibility of App Store badge
+   * @type {boolean}
+   */
+  @property({ type: Boolean, attribute: "hide-image" })
+  hideImage = false
+
+  /**
+   * Link to the F-Droid app page.
+   */
   @state()
   fDroidAppLink = "https://f-droid.org/packages/openfoodfacts.github.scrachx.openfood"
 
+  /**
+   * Generates the URL suffix for Android app links.
+   * @param language - The language code.
+   * @param campaign - The campaign identifier.
+   * @returns The URL suffix with UTM parameters.
+   */
   private getAndroidUrlSuffix(language: string, campaign: string): string {
     return `?utm_source=off&utf_medium=web&utm_campaign=${campaign}_${language}`
   }
 
+  /**
+   * Generates the Google Play Store link for the app.
+   * @param language - The language code.
+   * @returns The Google Play Store link.
+   */
   getAndroidAppLink(language: string): string {
     const baseURI = `https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner&hl=${language}`
     return `${baseURI}${this.getAndroidUrlSuffix(language, "install_the_app_android_footer")}`
   }
 
+  /**
+   * Generates the APK download link for the app.
+   * @param language - The language code.
+   * @returns The APK download link.
+   */
   getAndroidApkAppLink(language: string): string {
     const baseURI = "https://github.com/openfoodfacts/smooth-app/releases/latest"
     return `${baseURI}${this.getAndroidUrlSuffix(language, "install_the_app_apk_footer")}`
   }
 
+  /**
+   * Generates the path to the Google Play Store badge icon.
+   * @param language - The language code.
+   * @returns The path to the badge icon.
+   */
   getAndroidAppIconPath(language: string): string {
     return `https://play.google.com/intl/en_us/badges/static/images/badges/${language}_badge_web_generic.png`
   }
 
+  /**
+   * Generates the path to the F-Droid badge icon.
+   * @param language - The language code.
+   * @returns The path to the badge icon.
+   */
   getFDroidAppIconPath(language: string): string {
     return `https://fdroid.gitlab.io/artwork/badge/get-it-on-${language}.png`
   }
 
+  /**
+   * Generates the path to the Apple App Store badge icon.
+   * Note: This code does not handle the US locale specifically.
+   * @param language - The language code.
+   * @returns The path to the badge icon.
+   */
   getIosAppIconPath(language: string): string {
     if (language === "en") {
       return "appstore/black/appstore_UK.svg"
@@ -193,12 +265,26 @@ export class MobileBadges extends LitElement {
     return `appstore/black/appstore_${language.toLocaleUpperCase()}.svg`
   }
 
+  /**
+   * Generates the Apple App Store link for the app.
+   * @param language - The language code.
+   * @returns The Apple App Store link.
+   */
   getIosAppLink(language: string): string {
     const baseURI =
       "https://apps.apple.com/app/open-food-facts/id588797948?utm_source=off&utf_medium=web"
     return `${baseURI}&utm_campaign=install_the_app_ios_footer_${language}`
   }
 
+  /**
+   * Generates the HTML for a badge link.
+   * @param href - The URL for the badge link.
+   * @param src - The source of the badge image.
+   * @param alt - The alt text for the badge image.
+   * @param id - The id for the badge image.
+   * @param errorHandler - The error handler for the image.
+   * @returns The HTML template for the badge link.
+   */
   private generateBadgeLink(
     href: string,
     src: string,
@@ -221,6 +307,10 @@ export class MobileBadges extends LitElement {
     `
   }
 
+  /**
+   * Filters the badges based on the hide properties.
+   * @returns The filtered list of badges.
+   **/
   getFilteredBadges(): Badge[] {
     const language = getLocale()
     const badges: Badge[] = [
@@ -265,15 +355,21 @@ export class MobileBadges extends LitElement {
         },
       },
     ]
-    return badges.filter((badge) => !badge.hide)
+
+    const filteredBadges = badges.filter((badge) => badge.hide == false)
+    return filteredBadges
   }
 
+  /**
+   * Renders the image if hideImage is false
+   * @returns The image HTML or nothing if hideImage is true.
+   **/
   renderImage() {
-    if (this.hideImage) return nothing
-
+    if (this.hideImage) {
+      return nothing
+    }
     return html`
-      <div class="logo-container" style="--badge-text-color: ${this.color};"> 
-        <!-- ✅ Set color dynamically using CSS variable -->
+      <div class="logo-container">
         <img
           class="responsive-image"
           src="${getImageUrl("app-icon-in-the-clouds.svg")}"
@@ -282,32 +378,36 @@ export class MobileBadges extends LitElement {
         />
         <div id="footer_scan" style="display:block">
           <div id="footer_install_the_app">${msg("Install the app!")}</div>
-          ${msg(html`Scan your <span class="everyday">everyday</span> <span class="foods">foods</span>`)}
+          <!-- TODO find fix to add text between span for translations ex for fr : "Scannez vos <span class="foods">aliments</span> de votre <span class="everyday">quotidien</span>" -->
+          ${msg(
+            html`Scan your <span class="everyday">everyday</span> <span class="foods">foods</span>`
+          )}
         </div>
       </div>
     `
   }
 
+  /**
+   * Renders the badges if there are any filtered badges
+   * @returns The badges HTML or nothing if there are no filtered badges.
+   **/
   renderBadges() {
     const filteredBadges = this.getFilteredBadges()
-    return html`
-      ${filteredBadges.length > 0
-        ? html`
-            <div class="badge-container">
-              ${filteredBadges.map((badge) =>
-                this.generateBadgeLink(badge.href, badge.src, badge.alt, badge.id, badge.errorHandler)
-              )}
-            </div>
-          `
-        : ""}
-    `
+
+    return html` ${filteredBadges.length > 0
+      ? html`
+          <div class="badge-container ">
+            ${filteredBadges.map((badge) =>
+              this.generateBadgeLink(badge.href, badge.src, badge.alt, badge.id, badge.errorHandler)
+            )}
+          </div>
+        `
+      : ""}`
   }
 
   override render() {
     return html`
-      <div id="install_the_app_block">
-        ${this.renderImage()} ${this.renderBadges()}
-      </div>
+      <div class="" id="install_the_app_block">${this.renderImage()} ${this.renderBadges()}</div>
     `
   }
 }


### PR DESCRIPTION

This PR adds a textColor property to the <mobile-badges> web component to allow customizable text color from outside the component (e.g., from other pages or frameworks like Svelte). Since dynamic values can’t be injected into static styles, the textColor is applied via inline style binding inside the renderImage() method . It allows passing textColor as an HTML attribute.



