### PR TITLE
style: Enable automatic dark mode detection for all components using a shared listener

### DIFF
--- a/web-components/index.html
+++ b/web-components/index.html
@@ -83,11 +83,11 @@
       </div>
 
       <div style="display: flex; justify-content: center; margin:auto">
-        <donation-banner darkmode currentYear="2027" />
+        <donation-banner currentYear="2027" />
       </div>
 
       <div style="display: flex; margin: 2rem; margin-left: 10px; margin-right: 10px">
-        <mobile-badges darkmode style="width: 100%" />
+        <mobile-badges style="width: 100%" />
       </div>
 
       <div style="display: flex; margin: 2rem; margin-left: 10px; margin-right: 10px">
@@ -126,7 +126,7 @@
       </div>
     </div>
     <div style="display: flex; margin: 1rem; justify-content: center; flex-wrap: wrap">
-      <product-card product='{"brands":"Deliciously Ella","code":"5060482841565","ecoscore_grade":"b","image_front_small_url":"https://images.openfoodfacts.org/images/products/506/048/284/1565/front_en.38.200.jpg","nova_group":4,"nutriscore_grade":"b","product_name":"Nutty Granola","product_type":"food","quantity":"380g"}' darkmode></product-card>
+      <product-card product='{"brands":"Deliciously Ella","code":"5060482841565","ecoscore_grade":"b","image_front_small_url":"https://images.openfoodfacts.org/images/products/506/048/284/1565/front_en.38.200.jpg","nova_group":4,"nutriscore_grade":"b","product_name":"Nutty Granola","product_type":"food","quantity":"380g"}'></product-card>
     </div>
   </body>
 </html>

--- a/web-components/src/components/donation-banner/donation-banner.ts
+++ b/web-components/src/components/donation-banner/donation-banner.ts
@@ -3,6 +3,7 @@ import { customElement, property } from "lit/decorators.js"
 import { localized, msg, str } from "@lit/localize"
 import { getImageUrl, languageCode } from "../../signals/app"
 import { classMap } from "lit/directives/class-map.js"
+import { darkModeListener } from "../../utils/dark-mode-listener"
 
 /**
  * Donation banner
@@ -33,10 +34,23 @@ export class DonationBanner extends LitElement {
   currentYear: string = this.getDefaultYear()
 
   /**
-   * Whether to apply dark mode styling
+   * Whether to apply dark mode styling (auto-detected from prefers-color-scheme)
    */
-  @property({ type: Boolean })
-  darkMode = false
+  isDarkMode = darkModeListener.darkMode
+  private _darkModeCb = (isDark: boolean) => {
+    this.isDarkMode = isDark
+    this.requestUpdate()
+  }
+
+  override connectedCallback() {
+    super.connectedCallback()
+    darkModeListener.subscribe(this._darkModeCb)
+  }
+
+  override disconnectedCallback() {
+    darkModeListener.unsubscribe(this._darkModeCb)
+    super.disconnectedCallback()
+  }
 
   getDefaultYear() {
     return new Date().getFullYear().toString()
@@ -262,7 +276,7 @@ export class DonationBanner extends LitElement {
   `
 
   override render() {
-    const rootClasses = { "dark-mode": this.darkMode }
+    const rootClasses = { "dark-mode": this.isDarkMode }
     return html`<section class=${classMap(rootClasses)}>
       <div class="donation-banner-footer row">
         <div class="donation-banner-footer__left-aside">

--- a/web-components/src/components/mobile-badges/mobile-badges.ts
+++ b/web-components/src/components/mobile-badges/mobile-badges.ts
@@ -3,6 +3,7 @@ import { customElement, state, property } from "lit/decorators.js"
 import { localized, msg } from "@lit/localize"
 import { getImageUrl, languageCode } from "../../signals/app"
 import { classMap } from "lit/directives/class-map.js"
+import { darkModeListener } from "../../utils/dark-mode-listener"
 
 export type Badge = {
   href: string
@@ -31,7 +32,7 @@ export class MobileBadges extends LitElement {
         display: block;
       }
       .dark-mode {
-        background-color: #2d2724;
+        background-color: #201a17;
         color: #f9f7f5;
       }
       #footer_scan {
@@ -234,10 +235,23 @@ export class MobileBadges extends LitElement {
   hideImage = false
 
   /**
-   * Whether to apply dark mode styling
+   * Whether to apply dark mode styling (auto-detected from prefers-color-scheme)
    */
-  @property({ type: Boolean })
-  darkMode = false
+  isDarkMode = darkModeListener.darkMode
+  private _darkModeCb = (isDark: boolean) => {
+    this.isDarkMode = isDark
+    this.requestUpdate()
+  }
+
+  override connectedCallback() {
+    super.connectedCallback()
+    darkModeListener.subscribe(this._darkModeCb)
+  }
+
+  override disconnectedCallback() {
+    darkModeListener.unsubscribe(this._darkModeCb)
+    super.disconnectedCallback()
+  }
 
   /**
    * Link to the F-Droid app page.
@@ -447,7 +461,7 @@ export class MobileBadges extends LitElement {
   }
 
   override render() {
-    const rootClasses = { "dark-mode": this.darkMode }
+    const rootClasses = { "dark-mode": this.isDarkMode }
     return html`
       <div class=${classMap(rootClasses)} id="install_the_app_block">
         ${this.renderImage()} ${this.renderBadges()}

--- a/web-components/src/components/product-card/product-card.ts
+++ b/web-components/src/components/product-card/product-card.ts
@@ -3,6 +3,7 @@ import { customElement, property, state } from "lit/decorators.js"
 import { classMap } from "lit/directives/class-map.js"
 import { KP_ATTRIBUTE_IMG } from "../../utils/openfoodfacts"
 import { getImageUrl } from "../../signals/app"
+import { darkModeListener } from "../../utils/dark-mode-listener"
 
 interface NavigationState {
   to: {
@@ -261,16 +262,29 @@ export class ProductCard extends LitElement {
   greenscoreSrc = ""
 
   /**
-   * Whether to apply dark mode styling
-   */
-  @property({ type: Boolean })
-  darkMode = false
-
-  /**
    * Placeholder image URL for products without an image
    */
   @property({ type: String })
   placeholderImage = getImageUrl("Placeholder.svg")
+
+  /**
+   * Whether to apply dark mode styling (auto-detected from prefers-color-scheme)
+   */
+  isDarkMode = darkModeListener.darkMode
+  private _darkModeCb = (isDark: boolean) => {
+    this.isDarkMode = isDark
+    this.requestUpdate()
+  }
+
+  override connectedCallback() {
+    super.connectedCallback()
+    darkModeListener.subscribe(this._darkModeCb)
+  }
+
+  override disconnectedCallback() {
+    darkModeListener.unsubscribe(this._darkModeCb)
+    super.disconnectedCallback()
+  }
 
   /**
    * Updates score image URLs based on the product's nutrition grades, nova group, and greenscore
@@ -291,7 +305,7 @@ export class ProductCard extends LitElement {
     const hasProductImage = Boolean(this.product.image_front_small_url)
     const cardClasses = {
       "card-container": true,
-      "dark-mode": this.darkMode,
+      "dark-mode": this.isDarkMode,
     }
 
     return html`

--- a/web-components/src/utils/dark-mode-listener.ts
+++ b/web-components/src/utils/dark-mode-listener.ts
@@ -1,0 +1,37 @@
+// src/utils/dark-mode-listener.ts
+// Simple singleton for dark mode detection and subscription
+
+export type DarkModeCallback = (isDark: boolean) => void
+
+class DarkModeListener {
+  private isDark: boolean
+  private listeners: Set<DarkModeCallback> = new Set()
+  private mq: MediaQueryList
+
+  constructor() {
+    this.mq = window.matchMedia("(prefers-color-scheme: dark)")
+    this.isDark = this.mq.matches
+    this.mq.addEventListener("change", this.handleChange)
+  }
+
+  private handleChange = (e: MediaQueryListEvent) => {
+    this.isDark = e.matches
+    this.listeners.forEach((cb) => cb(this.isDark))
+  }
+
+  get darkMode() {
+    return this.isDark
+  }
+
+  subscribe(cb: DarkModeCallback) {
+    this.listeners.add(cb)
+    // Immediately call with current value
+    cb(this.isDark)
+  }
+
+  unsubscribe(cb: DarkModeCallback) {
+    this.listeners.delete(cb)
+  }
+}
+
+export const darkModeListener = new DarkModeListener()


### PR DESCRIPTION
### What
This PR introduces a shared `darkModeListener` utility that enables any component to automatically detect and respond to the system’s dark mode preference.

- Updated `donation-banner`, `mobile-badges`, and `product-card` to use this listener for seamless dark mode support.
- Removed manual dark mode property from these components.
- Any component can now easily benefit from automatic dark mode detection by subscribing to the shared listener.

### Part of 
- https://github.com/orgs/openfoodfacts/projects/157/views/1?pane=issue&itemId=115144718&issue=openfoodfacts%7Copenfoodfacts-explorer%7C524
