### PR TITLE
fix: Product card height  inconsistency fixed

### DIFF
--- a/web-components/src/components/product-card/product-card.ts
+++ b/web-components/src/components/product-card/product-card.ts
@@ -55,8 +55,7 @@ export class ProductCard extends LitElement {
     .card-container {
       display: flex;
       flex-direction: column;
-      height: auto;
-      min-height: 10rem;
+      height: 10rem;
       width: 100%;
       max-width: 100%;
       border-radius: 1rem;
@@ -72,7 +71,6 @@ export class ProductCard extends LitElement {
     .card-content {
       display: flex;
       flex: 1;
-      height: 10rem;
       border-radius: 1rem;
     }
 
@@ -82,7 +80,7 @@ export class ProductCard extends LitElement {
     }
 
     .image-container {
-      height: 100%;
+      height: 10rem;
       width: 40%;
       text-align: center;
       font-size: 0.875rem;


### PR DESCRIPTION
### What
- Product card height was getting inconsistent. It occurred due to this PR:
https://github.com/openfoodfacts/openfoodfacts-webcomponents/pull/235

### Screenshot
Earlier:
<img width="2335" height="485" alt="Screenshot 2025-08-17 at 8 43 52 PM" src="https://github.com/user-attachments/assets/605ac6d8-6f55-41bf-a8bc-34072c5d000e" />

After:
<img width="2280" height="261" alt="Screenshot 2025-08-17 at 8 45 16 PM" src="https://github.com/user-attachments/assets/df858d2e-7a1b-4520-a8fe-06866c411050" />
