### PR TITLE
fix: Include credentials in robotoff read requests

### DIFF
--- a/web-components/src/api/robotoff.ts
+++ b/web-components/src/api/robotoff.ts
@@ -139,7 +139,8 @@ const robotoff = {
     }
     const apiUrl = getApiUrl(`/questions/${code}`)
     const url = addParamsToUrl(apiUrl, questionRequestParams)
-    const response = await fetch(url)
+    # Note: we need credentials to be sure to have all questions
+    const response = await fetch(url, {credentials: "include"})
     const result: QuestionsResponse = await response.json()
     return result
   },
@@ -155,7 +156,8 @@ const robotoff = {
   >(requestParams: InsightsRequestParams = {}) {
     const apiUrl = getApiUrl("/insights")
     const url = addParamsToUrl(apiUrl, requestParams)
-    const response = await fetch(url)
+    # Note: we need credentials to be sure to have all insights
+    const response = await fetch(url, {credentials: "include"})
     const result: InsightsResponse<T> = await response.json()
     return result
   },

--- a/web-components/src/api/robotoff.ts
+++ b/web-components/src/api/robotoff.ts
@@ -140,7 +140,7 @@ const robotoff = {
     const apiUrl = getApiUrl(`/questions/${code}`)
     const url = addParamsToUrl(apiUrl, questionRequestParams)
     // Note: we need credentials to be sure to have all questions
-    const response = await fetch(url, {credentials: "include"})
+    const response = await fetch(url, { credentials: "include" })
     const result: QuestionsResponse = await response.json()
     return result
   },
@@ -157,7 +157,7 @@ const robotoff = {
     const apiUrl = getApiUrl("/insights")
     const url = addParamsToUrl(apiUrl, requestParams)
     // Note: we need credentials to be sure to have all insights
-    const response = await fetch(url, {credentials: "include"})
+    const response = await fetch(url, { credentials: "include" })
     const result: InsightsResponse<T> = await response.json()
     return result
   },

--- a/web-components/src/api/robotoff.ts
+++ b/web-components/src/api/robotoff.ts
@@ -139,7 +139,7 @@ const robotoff = {
     }
     const apiUrl = getApiUrl(`/questions/${code}`)
     const url = addParamsToUrl(apiUrl, questionRequestParams)
-    # Note: we need credentials to be sure to have all questions
+    // Note: we need credentials to be sure to have all questions
     const response = await fetch(url, {credentials: "include"})
     const result: QuestionsResponse = await response.json()
     return result
@@ -156,7 +156,7 @@ const robotoff = {
   >(requestParams: InsightsRequestParams = {}) {
     const apiUrl = getApiUrl("/insights")
     const url = addParamsToUrl(apiUrl, requestParams)
-    # Note: we need credentials to be sure to have all insights
+    // Note: we need credentials to be sure to have all insights
     const response = await fetch(url, {credentials: "include"})
     const result: InsightsResponse<T> = await response.json()
     return result


### PR DESCRIPTION
Because the robotoff response can depend on this.

For example https://robotoff.openfoodfacts.org/api/v1/questions/3336971407225?lang=en (at the time of writing) return an insight only if you are authenticated.

(it might be, in this case, because we have a skip by DEVICE_ID as the question was voted already, but if I'm logged in, it should be skip by USER).