### PR TITLE
fix: Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -5,6 +5,9 @@ on:
     branches: [ crowdin-trigger ]
 jobs:
   synchronize-with-crowdin:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-webcomponents/security/code-scanning/24](https://github.com/openfoodfacts/openfoodfacts-webcomponents/security/code-scanning/24)

To resolve the issue, explicitly specify the required minimal permissions for the workflow/job to restrict the GITHUB_TOKEN. Since the workflow contains a job that checks out code, pushes translation updates, and creates pull requests, the minimal permissions required are:
- `contents: write` (to push commits to the repository)
- `pull-requests: write` (to create and update pull requests)

These permissions should be assigned either at the root of the workflow file or specifically on the affected job. For clarity and future extensibility, it's best to set them at the job-level. The relevant fix is to add the following block above the `runs-on: ubuntu-latest` line for the `synchronize-with-crowdin` job:

```yaml
    permissions:
      contents: write
      pull-requests: write
```

No imports, external libraries, or variable/method definitions are required; this is a configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
