### PR TITLE
fix: Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-webcomponents/security/code-scanning/25](https://github.com/openfoodfacts/openfoodfacts-webcomponents/security/code-scanning/25)

The best way to fix this problem is to add a `permissions` block specifying the least privilege needed for this workflow/job. The workflow steps in `build` do not require write access—they only need to clone the repo and install/build/lint code. Therefore, `contents: read` is sufficient. The fix is to add the following under the `build` job—either at the job or workflow level. Since there is only one job, the most targeted but also clear fix is to add a `permissions` block directly under `build` (after `runs-on: ubuntu-latest`). Only a small YAML block needs to be inserted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
