### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,4 +1,7 @@
 name: "Semantic PRs"
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request_target:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-webcomponents/security/code-scanning/27](https://github.com/openfoodfacts/openfoodfacts-webcomponents/security/code-scanning/27)

To fix this problem, you should add a `permissions` block that gives only the minimum necessary privileges to the workflow. The minimal block for typical semantic PR validation is:
```yaml
permissions:
  contents: read
  pull-requests: write
```
This block can (and should) be placed at the workflow level, directly after the `name` field, as it then applies to all jobs by default. If later you want to further restrict (or expand) permissions for specific jobs, you can do so at the job level. The change should be made right after line 1 in `.github/workflows/semantic-pr.yml`.

No additional imports, methods, or variable definitions are needed for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
