### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-projects-ventilation.yml
+++ b/.github/workflows/github-projects-ventilation.yml
@@ -1,4 +1,6 @@
 name: Ventilate issues to the right GitHub projects
+permissions:
+  contents: read
 
 on:
   issues:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-webcomponents/security/code-scanning/9](https://github.com/openfoodfacts/openfoodfacts-webcomponents/security/code-scanning/9)

The best way to fix this problem is to explicitly specify the required permissions at the workflow or job level. Since this workflow interacts with issues and pull requests, the action (`actions/add-to-project`) does not use the implicit GITHUB_TOKEN, but best practice is to still explicitly deny unnecessary privileges.  

The correct approach is to add a `permissions` block at the workflow root if all jobs have the same requirements, or at the job level otherwise. In this case, it is sufficient to add it at the workflow root (top of the file, below the `name:` and before `on:`). For a minimal starting point:  
- `contents: read` (required for basic repo read operations, typical minimal requirement)
- Optionally, if the workflow requires updating issues or PRs via GITHUB_TOKEN (not the custom PAT), you might add `issues: write` and/or `pull-requests: write`. But here, values can be minimal as most write happens via the PAT token (`github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}`).

Thus, the minimal safe permissions block is:
```yaml
permissions:
  contents: read
```
You may need to expand to include issue/project/PRs writing if GITHUB_TOKEN is used for that, but in this sample it is not.

**Where to make the change:**  
Edit the beginning of `.github/workflows/github-projects-ventilation.yml`, after line 1 (`name: ...`), and before line 3 (`on:`), inserting the block:
```yaml
permissions:
  contents: read
```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
