### PR TITLE
feat(taxonomy-graphflow): new component to visualize graphically category taxonomy

### DIFF
--- a/web-components/package-lock.json
+++ b/web-components/package-lock.json
@@ -13,6 +13,7 @@
         "@lit/localize": "^0.12.2",
         "@lit/task": "^1.0.2",
         "cropperjs": "^2.0.0",
+        "cytoscape": "^3.33.1",
         "dayjs": "^1.11.18",
         "diff": "^8.0.1",
         "dompurify": "^3.2.6",
@@ -1414,19 +1415,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -4830,15 +4818,6 @@
         "node": ">=12.17"
       }
     },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/comment-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
@@ -5023,6 +5002,15 @@
       "integrity": "sha512-j59k0ExGCKA8T6Mzaq+7axc+KVHwpEphEERU7VZ99260npu/p/9kd+Db+I3cGKxHkM5y6q5gnlXn00mzRQkX2A==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -9537,27 +9525,6 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/terser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/text-decoder": {

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -54,6 +54,7 @@
     "@lit/localize": "^0.12.2",
     "@lit/task": "^1.0.2",
     "cropperjs": "^2.0.0",
+    "cytoscape": "^3.33.1",
     "dayjs": "^1.11.18",
     "diff": "^8.0.1",
     "dompurify": "^3.2.6",

--- a/web-components/src/api/openfoodfacts.ts
+++ b/web-components/src/api/openfoodfacts.ts
@@ -4,6 +4,7 @@ import type {
   NutrientsOrderRequest,
   NutrientsParams,
   RequestProductParams,
+  TaxonomyCategoryRequest,
 } from "../types/openfoodfacts"
 import { addParamsToUrl } from "../utils"
 
@@ -53,4 +54,18 @@ export async function fetchNutrientsOrder(params: NutrientsParams) {
     throw new Error("Failed to fetch nutrients order")
   }
   return (await response.json()) as NutrientsOrderRequest
+}
+
+/**
+ * Fetch product data from openfoodfacts
+ * @param categoryName category name in english
+ * @returns The taxonomy category data
+ */
+export async function fetchTaxonomyCategory(categoryName: string) {
+  const url = getUrl(`${ApiBaseUrl.API_V2}/taxonomy?tagtype=categories&tags=en:${categoryName}`)
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error("Failed to fetch taxonomy category data")
+  }
+  return (await response.json()) as TaxonomyCategoryRequest
 }

--- a/web-components/src/components/taxonomy-graph/taxonomy-graph.stories.ts
+++ b/web-components/src/components/taxonomy-graph/taxonomy-graph.stories.ts
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/web-components-vite"
+import "./taxonomy-graph"
+
+const meta: Meta = {
+  title: "Taxonomy/graph",
+  component: "taxonomy-graph",
+}
+export default meta
+
+type Story = StoryObj
+
+export const Basic: Story = {
+  args: {
+    categoriesNames: ["gnocchi", "terrine"],
+  },
+}

--- a/web-components/src/components/taxonomy-graph/taxonomy-graph.ts
+++ b/web-components/src/components/taxonomy-graph/taxonomy-graph.ts
@@ -1,0 +1,93 @@
+import { LitElement, html, css } from "lit"
+import { customElement, property } from "lit/decorators.js"
+import cytoscape from "cytoscape"
+import { fetchTaxonomyCategory } from "../../api/openfoodfacts"
+import { isTaxonomyCategoryDetail } from "../../types/openfoodfacts"
+
+/**
+ */
+@customElement("taxonomy-graph")
+export class TaxonomyGraph extends LitElement {
+  /**
+   * The root categories to display
+   */
+  @property({ type: Array })
+  categoriesNames: string[] = ["gnocchi", "terrine"]
+
+  static styles = css`
+    #cy {
+      width: 100%;
+      height: 600px;
+      border: 1px solid #ccc;
+    }
+  `
+
+  async addCategoryAndChildren(categoryName: string) {
+    const categories = await fetchTaxonomyCategory(categoryName)
+    if (!isTaxonomyCategoryDetail(categories)) {
+      console.warn(`category ${categoryName} doesn't seem to exist since API returned`, categories)
+      return []
+    }
+    const graph_elements = []
+    for (var categoryId in categories) {
+      const category = categories[categoryId]
+      graph_elements.push({ data: { id: categoryId } })
+      for (var child of category.children) {
+        graph_elements.push({ data: { id: child } })
+        graph_elements.push({
+          data: {
+            id: `${categoryId}->${child}`,
+            source: categoryId,
+            target: child,
+          },
+        })
+      }
+    }
+    return graph_elements
+  }
+
+  async firstUpdated() {
+    const graph_elements = []
+    for (var categoryName of this.categoriesNames) {
+      var new_elements = await this.addCategoryAndChildren(categoryName)
+      console.log("new elements", new_elements)
+      graph_elements.push(...new_elements)
+    }
+    cytoscape({
+      container: this.renderRoot.querySelector("#cy"),
+      elements: graph_elements,
+      style: [
+        {
+          selector: "node",
+          style: {
+            "background-color": "#0074D9",
+            label: "data(id)",
+          },
+        },
+        {
+          selector: "edge",
+          style: {
+            width: 3,
+            "line-color": "#ccc",
+            "target-arrow-color": "#ccc",
+            "target-arrow-shape": "triangle",
+          },
+        },
+      ],
+      // Here is the doc for layouts : https://js.cytoscape.org/#layouts
+      layout: {
+        name: "breadthfirst"
+      }
+    });
+  }
+
+  render() {
+    return html`<div id="cy"></div>`
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "taxonomy-graph": TaxonomyGraph
+  }
+}

--- a/web-components/src/components/taxonomy-graph/taxonomy-graph.ts
+++ b/web-components/src/components/taxonomy-graph/taxonomy-graph.ts
@@ -76,9 +76,10 @@ export class TaxonomyGraph extends LitElement {
       ],
       // Here is the doc for layouts : https://js.cytoscape.org/#layouts
       layout: {
-        name: "breadthfirst"
-      }
-    });
+        name: "breadthfirst",
+        direction: "rightward",
+      },
+    })
   }
 
   render() {

--- a/web-components/src/components/taxonomy-graph/taxonomy-graph.ts
+++ b/web-components/src/components/taxonomy-graph/taxonomy-graph.ts
@@ -12,7 +12,7 @@ export class TaxonomyGraph extends LitElement {
    * The root categories to display
    */
   @property({ type: Array })
-  categoriesNames: string[] = ["gnocchi", "terrine"]
+  categoriesNames: string[] = []
 
   static styles = css`
     #cy {
@@ -28,13 +28,13 @@ export class TaxonomyGraph extends LitElement {
       console.warn(`category ${categoryName} doesn't seem to exist since API returned`, categories)
       return []
     }
-    const graph_elements = []
+    const graphElements = []
     for (var categoryId in categories) {
       const category = categories[categoryId]
-      graph_elements.push({ data: { id: categoryId } })
+      graphElements.push({ data: { id: categoryId } })
       for (var child of category.children) {
-        graph_elements.push({ data: { id: child } })
-        graph_elements.push({
+        graphElements.push({ data: { id: child } })
+        graphElements.push({
           data: {
             id: `${categoryId}->${child}`,
             source: categoryId,
@@ -43,19 +43,18 @@ export class TaxonomyGraph extends LitElement {
         })
       }
     }
-    return graph_elements
+    return graphElements
   }
 
   async firstUpdated() {
-    const graph_elements = []
+    const graphElements = []
     for (var categoryName of this.categoriesNames) {
       var new_elements = await this.addCategoryAndChildren(categoryName)
-      console.log("new elements", new_elements)
-      graph_elements.push(...new_elements)
+      graphElements.push(...new_elements)
     }
     cytoscape({
       container: this.renderRoot.querySelector("#cy"),
-      elements: graph_elements,
+      elements: graphElements,
       style: [
         {
           selector: "node",

--- a/web-components/src/off-webcomponents.ts
+++ b/web-components/src/off-webcomponents.ts
@@ -17,6 +17,7 @@ export { AutocompleteInput } from "./components/shared/autocomplete-input"
 export { RobotoffIngredientDetection as RobotoffCrops } from "./components/robotoff-ingredient-detection/robotoff-ingredient-detection"
 export { ProductCard } from "./components/product-card/product-card"
 export { NewsFeed } from "./components/news-feed/news-feed"
+export { TaxonomyGraph } from "./components/taxonomy-graph/taxonomy-graph"
 
 // Will be added in the future when design is ready
 // export { KnowledgePanelsComponent } from "./components/knowledge-panels/knowledge-panels"

--- a/web-components/src/types/openfoodfacts.ts
+++ b/web-components/src/types/openfoodfacts.ts
@@ -42,3 +42,19 @@ export interface NutrientOrderRequest {
 export interface NutrientsOrderRequest {
   nutrients: NutrientOrderRequest[]
 }
+
+export interface TaxonomyCategoryDetail {
+  children: string[]
+  description: string
+  name: string
+  parents: string[]
+}
+
+export function isTaxonomyCategoryDetail(obj: {} | TaxonomyCategoryDetail) {
+  for (var key in obj) {
+    if (!("name" in obj[key])) return false
+  }
+  return true
+}
+
+export type TaxonomyCategoryRequest = Record<string, TaxonomyCategoryDetail | {}>

--- a/web-components/src/types/openfoodfacts.ts
+++ b/web-components/src/types/openfoodfacts.ts
@@ -50,7 +50,10 @@ export interface TaxonomyCategoryDetail {
   parents: string[]
 }
 
-export function isTaxonomyCategoryDetail(obj: {} | TaxonomyCategoryDetail) {
+export function isTaxonomyCategoryDetail(
+  obj: {} | TaxonomyCategoryDetail
+): obj is TaxonomyCategoryDetail {
+  // Check that obj is a valid taxonomy category API response by checking it has at least the property 'name'
   for (var key in obj) {
     if (!("name" in obj[key])) return false
   }


### PR DESCRIPTION
### What
It's my first contribution in this repo and I'm not very experiences in typescript, but I want to add a component that allow to visualize the category taxonomy as a graph-flow.
So I added a component and a story.
Here is a screenshot of default graph in story :
<img width="810" height="567" alt="image" src="https://github.com/user-attachments/assets/524a3a6f-98be-4f7c-9661-8baa4cad84e4" />
It can also be Top to Bottom if you prefer:
<img width="1538" height="328" alt="image" src="https://github.com/user-attachments/assets/c902108e-5cca-4794-bf68-08d41e09b092" />


I've had to add a function to call taxonomy API, and also a new type corresponding to the API response, but I'm not sure I'm using the correct API point. And I'm also not sure in which files I should have made this change.

I hope I can have help to enhance the code and even finish this new component.
I dream of this component being added to the OFF page https://world-fr.openfoodfacts.org/facets/categories/gnocchi for example
