### PR TITLE
feat: view only mode for folksonomy editor

### DIFF
--- a/web-components/src/components/folksonomy/folksonomy-editor-row.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor-row.ts
@@ -483,25 +483,27 @@ export class FolksonomyEditorRow extends LitElement {
               />`
             : this.value}
         </td>
-        <td>
-          <div class="button-container">
-            ${this.editable
-              ? html`
-                  <button class="button chocolate-button" @click=${this.handleSave}>
-                    ${msg("Save")}
-                  </button>
-                  <button class="button chocolate-button" @click=${this.handleCancel}>
-                    ${msg("Cancel")}
-                  </button>
-                `
-              : html`<button class="button chocolate-button" @click=${this.handleEdit}>
-                  ${msg("Edit")}
-                </button>`}
-            <button class="button chocolate-button" @click=${this.handleDelete}>
-              ${msg("Delete")}
-            </button>
-          </div>
-        </td>
+        ${this.pageType == "edit"
+          ? html`<td>
+              <div class="button-container">
+                ${this.editable
+                  ? html`
+                      <button class="button chocolate-button" @click=${this.handleSave}>
+                        ${msg("Save")}
+                      </button>
+                      <button class="button chocolate-button" @click=${this.handleCancel}>
+                        ${msg("Cancel")}
+                      </button>
+                    `
+                  : html`<button class="button chocolate-button" @click=${this.handleEdit}>
+                      ${msg("Edit")}
+                    </button>`}
+                <button class="button chocolate-button" @click=${this.handleDelete}>
+                  ${msg("Delete")}
+                </button>
+              </div>
+            </td>`
+          : null}
       </tr>
       ${this.showNewKeyModal
         ? html`<new-key-modal @close-modal=${this.handleCloseNewKeyModal}></new-key-modal>`

--- a/web-components/src/components/folksonomy/folksonomy-editor.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor.ts
@@ -266,7 +266,7 @@ export class FolksonomyEditor extends LitElement {
             >
               <span class="sort-header"> ${msg("Value")} ${this.renderSortIcon("value")} </span>
             </th>
-            <th>${msg("Actions")}</th>
+            ${this.pageType == "edit" ? html`<th>${msg("Actions")}</th>` : null}
           </tr>
           ${this.properties.map(
             (item, index) =>
@@ -279,12 +279,14 @@ export class FolksonomyEditor extends LitElement {
                 page-type=${this.pageType}
               ></folksonomy-editor-row>`
           )}
-          ${html`<folksonomy-editor-row
-            product-code=${this.productCode}
-            page-type=${this.pageType}
-            row-number=${this.properties.length + 1}
-            empty
-          ></folksonomy-editor-row>`}
+          ${this.pageType == "edit"
+            ? html`<folksonomy-editor-row
+                product-code=${this.productCode}
+                page-type=${this.pageType}
+                row-number=${this.properties.length + 1}
+                empty
+              ></folksonomy-editor-row>`
+            : null}
         </table>
       </form>
     `


### PR DESCRIPTION
If page-type=view we don't display action and the "add item" row.

This is more consistent for non logged in users on open food facts (and with the fact that we are in view mode).

Edit mode:
<img width="1617" height="814" alt="Capture d’écran du 2026-01-07 12-18-32" src="https://github.com/user-attachments/assets/d0d1782a-cf47-4046-affa-1afb90779dea" />

View mode:
<img width="1617" height="814" alt="Capture d’écran du 2026-01-07 12-18-44" src="https://github.com/user-attachments/assets/2565b476-fe56-4e0d-8e6a-ecb35fd0b903" />

