### PR TITLE
fix: Revert "chore(deps-dev): bump @storybook/addon-a11y from 9.1.6 to 9.1.15 in /web-components"

### DIFF
--- a/web-components/package-lock.json
+++ b/web-components/package-lock.json
@@ -26,7 +26,7 @@
         "@lit/localize-tools": "^0.8.0",
         "@open-wc/testing": "^4.0.0",
         "@openfoodfacts/openfoodfacts-nodejs": "^2.0.0-alpha.18",
-        "@storybook/addon-a11y": "^10.2.1",
+        "@storybook/addon-a11y": "^9.1.4",
         "@storybook/addon-docs": "^9.1.4",
         "@storybook/addon-vitest": "^9.1.4",
         "@storybook/builder-vite": "^9.1.4",
@@ -2348,9 +2348,9 @@
       ]
     },
     "node_modules/@storybook/addon-a11y": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.2.1.tgz",
-      "integrity": "sha512-2oVKs3gDveVYcAzcB/Ik6AQcNvZ+cmvJQxwf6GO7dNJ81uIwSsVS4JFyxt9KFCKVn3uR00OGwOtEmyMEtsTvDw==",
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-9.1.6.tgz",
+      "integrity": "sha512-jpuzbZlT8G1hx4N6nhhmxy6Lu+Xnz1oeGb2/pm+rKx2fZ4oy7yGRliRNOvpTy8MbkpnfMoLLrcqc66s/kfdf3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2362,7 +2362,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.2.1"
+        "storybook": "^9.1.6"
       }
     },
     "node_modules/@storybook/addon-docs": {

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -67,7 +67,7 @@
     "@lit/localize-tools": "^0.8.0",
     "@open-wc/testing": "^4.0.0",
     "@openfoodfacts/openfoodfacts-nodejs": "^2.0.0-alpha.18",
-    "@storybook/addon-a11y": "^10.2.1",
+    "@storybook/addon-a11y": "^9.1.4",
     "@storybook/addon-docs": "^9.1.4",
     "@storybook/addon-vitest": "^9.1.4",
     "@storybook/builder-vite": "^9.1.4",


### PR DESCRIPTION
Reverts openfoodfacts/openfoodfacts-webcomponents#349