### PR TITLE
feat: added highlight for ingredient confidence < 60%

### DIFF
--- a/web-components/src/components/robotoff-ingredient-detection/robotoff-ingredient-detection-form.ts
+++ b/web-components/src/components/robotoff-ingredient-detection/robotoff-ingredient-detection-form.ts
@@ -373,10 +373,7 @@ export class RobotoffIngredientDetectionForm extends LitElement {
    * @returns {TemplateResult}
    */
   renderIngredientsWithConfidence(insight: IngredientDetectionInsight): TemplateResult {
-    const highlights = parseIngredients(
-      insight.data.text,
-      insight.data.ingredients
-    )
+    const highlights = parseIngredients(insight.data.text, insight.data.ingredients)
 
     // Fallback: if no highlights found, show raw text
     if (highlights.length === 0) {

--- a/web-components/src/types/robotoff.ts
+++ b/web-components/src/types/robotoff.ts
@@ -143,7 +143,7 @@ interface Lang {
   confidence: number
 }
 
-interface IngredientDetection {
+export interface IngredientDetection {
   id: string
   text: string
   vegan?: string
@@ -161,6 +161,8 @@ interface IngredientDetection {
   processing?: string
   labels?: string
   bounding_box?: RobotoffBoundingBox
+  start?: number
+  end?: number
 }
 
 export type IngredientDetectionInsight = BaseInsight<{

--- a/web-components/src/utils/ingredient-highlight.ts
+++ b/web-components/src/utils/ingredient-highlight.ts
@@ -1,0 +1,97 @@
+import type { IngredientDetection } from "../types/robotoff"
+
+export interface IngredientHighlight {
+  text: string
+  confidence: number
+  isLowConfidence: boolean
+}
+
+export const CONFIDENCE_THRESHOLD = 60 
+
+export function isLowConfidence(score: number): boolean {
+  return score < CONFIDENCE_THRESHOLD
+}
+
+export function parseIngredients(
+  text: string,
+  ingredients: IngredientDetection[]
+): IngredientHighlight[] {
+  if (!ingredients || ingredients.length === 0) {
+    // Fallback: show each word from text as separate ingredient
+    const words = text.split(/[\s,]+/).filter((w) => w.length > 0)
+    return words.map((word) => ({
+      text: word,
+      confidence: 0,
+      isLowConfidence: true,
+    }))
+  }
+
+  // Process ingredients - search for them in text to find correct positions
+  const processedIngredients = ingredients.map((ing) => {
+    // Try to find the ingredient text in the main text (case insensitive)
+    const searchText = ing.text.toLowerCase()
+    const mainText = text.toLowerCase()
+    const start = mainText.indexOf(searchText)
+
+    if (start !== -1) {
+      return {
+        ...ing,
+        start,
+        end: start + ing.text.length,
+      }
+    }
+
+    // If not found, use original values or defaults
+    return {
+      ...ing,
+      start: ing.start ?? 0,
+      end: ing.end ?? ing.text.length,
+    }
+  })
+
+  // Sort ingredients by their position in the text
+  const sortedIngredients = [...processedIngredients]
+    .filter((ing) => ing.start !== undefined && ing.end !== undefined)
+    .sort((a, b) => (a.start ?? 0) - (b.start ?? 0))
+
+  // Remove duplicates (same text appearing multiple times)
+  const seen = new Set<string>()
+  const uniqueIngredients = sortedIngredients.filter((ing) => {
+    const key = ing.text.toLowerCase()
+    if (seen.has(key)) {
+      return false
+    }
+    seen.add(key)
+    return true
+  })
+
+  // Map to highlights, preserving order in text
+  return uniqueIngredients.map((ingredient) => {
+    // Handle both decimal (0.45) and percentage (45) formats
+    let confidence = ingredient.percent_estimate ?? 0
+    if (confidence <= 1 && confidence > 0) {
+      confidence = confidence * 100
+    }
+    return {
+      text: ingredient.text,
+      confidence: Math.round(confidence),
+      isLowConfidence: isLowConfidence(confidence),
+    }
+  })
+}
+
+export function highlightLowConfidence(
+  text: string,
+  ingredients: IngredientDetection[]
+): string {
+  const highlights = parseIngredients(text, ingredients)
+
+  return highlights
+    .map((item) => {
+      if (item.isLowConfidence) {
+        return `[LOW:${item.confidence}:${item.text}]`
+      }
+      return item.text
+    })
+    .join("")
+}

--- a/web-components/src/utils/ingredient-highlight.ts
+++ b/web-components/src/utils/ingredient-highlight.ts
@@ -6,7 +6,7 @@ export interface IngredientHighlight {
   isLowConfidence: boolean
 }
 
-export const CONFIDENCE_THRESHOLD = 60 
+export const CONFIDENCE_THRESHOLD = 60
 
 export function isLowConfidence(score: number): boolean {
   return score < CONFIDENCE_THRESHOLD
@@ -80,10 +80,7 @@ export function parseIngredients(
   })
 }
 
-export function highlightLowConfidence(
-  text: string,
-  ingredients: IngredientDetection[]
-): string {
+export function highlightLowConfidence(text: string, ingredients: IngredientDetection[]): string {
   const highlights = parseIngredients(text, ingredients)
 
   return highlights


### PR DESCRIPTION


### What
- <!-- Describe the Pull Request here -->
This PR introduces a feature so that which ever ingredient has cofidence score less 60 gets highlighted.
### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

https://github.com/user-attachments/assets/3faced98-c622-49e0-b104-815d7b3e5687

<img width="743" height="669" alt="Screenshot 2026-02-08 222647" src="https://github.com/user-attachments/assets/ae4843b2-0cda-4cba-a609-2533d50ad48f" />
### Fixes bug(s)
- <!-- #1, #2 and #3 (change by appropriate issues) -->
#176
### Part of 
- <!-- #1, please use the most granular issue possible -->

