### PR TITLE
fix: fix-417-418-419 Fixed dark mode issue in ingredients-spellcheck. ingredients-detection, nutrient extraction

### DIFF
--- a/web-components/src/components/shared/product-link-button.ts
+++ b/web-components/src/components/shared/product-link-button.ts
@@ -4,6 +4,8 @@ import { msg } from "@lit/localize"
 import { openfoodfactsApiUrl } from "../../signals/openfoodfacts"
 import { ButtonType, getButtonClasses } from "../../styles/buttons"
 import "../icons/external-link"
+import { darkModeListener } from "../../utils/dark-mode-listener"
+import { classMap } from "lit/directives/class-map.js"
 
 /**
  * A button component that displays as a link with a link icon.
@@ -11,11 +13,37 @@ import "../icons/external-link"
  */
 @customElement("product-link-button")
 export class ProductLinkButton extends LitElement {
+
+  isDarkMode = darkModeListener.darkMode
+
+  private _darkModeCb = (isDark: boolean) => {
+    this.isDarkMode = isDark
+    this.requestUpdate()
+  }
+
+  override connectedCallback() {
+    super.connectedCallback()
+    darkModeListener.subscribe(this._darkModeCb)
+  }
+
+  override disconnectedCallback() {
+    darkModeListener.unsubscribe(this._darkModeCb)
+    super.disconnectedCallback()
+  }
   static override styles = [
     getButtonClasses([ButtonType.LINK]),
     css`
       :host {
         display: inline-block;
+      }
+      .dark-mode {
+        color: #f9f7f5;
+      }
+
+      .dark-mode h2,
+      .dark-mode p,
+      .dark-mode button{
+        color: #f9f7f5;
       }
     `,
   ]
@@ -35,14 +63,16 @@ export class ProductLinkButton extends LitElement {
       console.error("Product code is required")
       return nothing
     }
-
+    const rootClasses = { "dark-mode": this.isDarkMode }
     return html`
+     <section class=${classMap(rootClasses)}> 
       <a href="${this.productUrl}" target="_blank" rel="noopener noreferrer">
         <button class="link-button button with-icon small">
           <external-link-icon></external-link-icon>
           <span>${msg("View Product")}</span>
         </button>
       </a>
+    </section>
     `
   }
 }

--- a/web-components/src/components/shared/product-link-button.ts
+++ b/web-components/src/components/shared/product-link-button.ts
@@ -13,7 +13,6 @@ import { classMap } from "lit/directives/class-map.js"
  */
 @customElement("product-link-button")
 export class ProductLinkButton extends LitElement {
-
   isDarkMode = darkModeListener.darkMode
 
   private _darkModeCb = (isDark: boolean) => {
@@ -42,7 +41,7 @@ export class ProductLinkButton extends LitElement {
 
       .dark-mode h2,
       .dark-mode p,
-      .dark-mode button{
+      .dark-mode button {
         color: #f9f7f5;
       }
     `,
@@ -65,14 +64,14 @@ export class ProductLinkButton extends LitElement {
     }
     const rootClasses = { "dark-mode": this.isDarkMode }
     return html`
-     <section class=${classMap(rootClasses)}> 
-      <a href="${this.productUrl}" target="_blank" rel="noopener noreferrer">
-        <button class="link-button button with-icon small">
-          <external-link-icon></external-link-icon>
-          <span>${msg("View Product")}</span>
-        </button>
-      </a>
-    </section>
+      <section class=${classMap(rootClasses)}>
+        <a href="${this.productUrl}" target="_blank" rel="noopener noreferrer">
+          <button class="link-button button with-icon small">
+            <external-link-icon></external-link-icon>
+                  <span>${msg("View Product")}</span>
+          </button>
+        </a>
+      </section>
     `
   }
 }

--- a/web-components/src/components/shared/product-link-button.ts
+++ b/web-components/src/components/shared/product-link-button.ts
@@ -68,7 +68,7 @@ export class ProductLinkButton extends LitElement {
         <a href="${this.productUrl}" target="_blank" rel="noopener noreferrer">
           <button class="link-button button with-icon small">
             <external-link-icon></external-link-icon>
-                  <span>${msg("View Product")}</span>
+            <span>${msg("View Product")}</span>
           </button>
         </a>
       </section>

--- a/web-components/src/components/shared/product-link-button.ts
+++ b/web-components/src/components/shared/product-link-button.ts
@@ -62,16 +62,18 @@ export class ProductLinkButton extends LitElement {
       console.error("Product code is required")
       return nothing
     }
-    const rootClasses = { "dark-mode": this.isDarkMode }
     return html`
-      <section class=${classMap(rootClasses)}>
-        <a href="${this.productUrl}" target="_blank" rel="noopener noreferrer">
-          <button class="link-button button with-icon small">
-            <external-link-icon></external-link-icon>
-            <span>${msg("View Product")}</span>
-          </button>
-        </a>
-      </section>
+      <a
+        href="${this.productUrl}"
+        class=${classMap({ "dark-mode": this.isDarkMode })}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <button class="link-button button with-icon small">
+          <external-link-icon></external-link-icon>
+          <span>${msg("View Product")}</span>
+        </button>
+      </a>
     `
   }
 }


### PR DESCRIPTION
### What
- The "View Product" link was not visible for dark mode in pages like  ingredients-spellcheck. ingredients-detection, nutrient extraction. Now the component will be visible in every page even in dark mode. 

### Screenshot
Before:
<img width="1121" height="240" alt="image" src="https://github.com/user-attachments/assets/124330fd-84c5-444d-ac4e-db952e4a301e" />
<img width="1180" height="312" alt="image" src="https://github.com/user-attachments/assets/b5ed1d79-2cde-4fca-b396-a47e3ce1a048" />

After:
The image background is not full dark due to storybook dark mode.
<img width="564" height="79" alt="image" src="https://github.com/user-attachments/assets/99504082-7afa-46d4-94bb-f0a8027a2f7f" />


### Fixes bug(s)
- #417  , #418  , #419   

### Part of 
- #416 #417 #418  
