### PR TITLE
fix: make dev script cross-platform on Windows

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -38,7 +38,7 @@
     "prepack": "npm run build",
     "analyze": "cem analyze --litelement --globs \"src/**/*.ts\"",
     "analyze:watch": "cem analyze --litelement --globs \"src/**/*.ts\" --watch",
-    "dev": "concurrently 'npm run storybook' 'npm run analyze:watch'",
+    "dev": "concurrently \"npm run storybook\" \"npm run analyze:watch\"",
     "test": "vitest",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build"


### PR DESCRIPTION
## Description

This updates the `dev` script to use double-quoted commands so `npm run dev` works on Windows PowerShell and remains compatible with macOS/Linux.

---

## Changes

- Replace single-quoted concurrent commands with double-quoted equivalents in `package.json:39`.

---

## Testing

- `npm run dev` (starts successfully)
- 

---

## Closes #430 