### PR TITLE
fix: prevent infinite spinner in ingredient spellcheck on API error

### DIFF
--- a/web-components/src/components/robotoff-ingredient-spellcheck/robotoff-ingredient-spellcheck.ts
+++ b/web-components/src/components/robotoff-ingredient-spellcheck/robotoff-ingredient-spellcheck.ts
@@ -265,20 +265,29 @@ export class RobotoffIngredientSpellcheck extends DisplayProductLinkMixin(
       return
     }
 
-    // Send the annotation to Robotoff API
-    await robotoff.annotateIngredientSpellcheck(
-      insight.id,
-      event.detail.annotation,
-      event.detail.correction
-    )
+    try {
+      // Send the annotation to Robotoff API
+      await robotoff.annotateIngredientSpellcheck(
+        insight.id,
+        event.detail.annotation,
+        event.detail.correction
+      )
 
-    await this.afterInsightAnnotation()
+      await this.afterInsightAnnotation()
 
-    if (this.allInsightsAreAnswered) {
+      if (this.allInsightsAreAnswered) {
+        this.dispatchIngredientSpellcheckStateEvent({
+          state: EventState.FINISHED,
+          insightId: insight.id,
+          ...event.detail,
+        })
+      }
+    } catch (error) {
+      console.error("Failed to submit annotation:", error)
+      await this.hideLoading()
       this.dispatchIngredientSpellcheckStateEvent({
-        state: EventState.FINISHED,
+        state: EventState.ERROR,
         insightId: insight.id,
-        ...event.detail,
       })
     }
   }

--- a/web-components/src/components/robotoff-modal/robotoff-modal.ts
+++ b/web-components/src/components/robotoff-modal/robotoff-modal.ts
@@ -137,6 +137,9 @@ export class RobotoffModal extends LitElement {
         // Send success event if no data to display because we don't want to show the modal again
         this.sendSuccessEvent(this.robotoffContributionType!)
         break
+      case EventState.ERROR:
+        this.isLoading = false
+        break
     }
   }
 

--- a/web-components/src/constants.ts
+++ b/web-components/src/constants.ts
@@ -40,6 +40,7 @@ export enum EventState {
   HAS_DATA = "has-data", // data to display
   ANNOTATED = "annotated", // user do one annotation
   FINISHED = "FINISHED", // user do all annotations
+  ERROR = "error", // an error occurred during annotation
 }
 
 export const DEFAULT_ASSETS_IMAGES_PATH = "/assets/images"


### PR DESCRIPTION
### What
Fix infinite spinner when saving ingredient spellcheck by adding error handling to `submitAnnotation()` so the loading state is always cleared if the API call fails (e.g., network/auth errors).

### Screenshot
Not applicable (behavioral fix; no visible UI change except spinner no longer stuck on error).

### Fixes bug(s)
- Fixes #288

### Part of
- Part of #29 (Web Components across Open Food Facts)