### PR TITLE
feat(folksonomy): made url property values clickable on the folksonomy engine web

### DIFF
--- a/web-components/src/components/folksonomy/folksonomy-editor-row.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor-row.ts
@@ -421,9 +421,14 @@ export class FolksonomyEditorRow extends LitElement {
   ]
 
   private isUrl(value: string): boolean {
+    const trimmedValue = value.trim()
+    if (!trimmedValue) {
+      return false
+    }
+
     try {
-      const url = new URL(value)
-      return url.protocol == "http:" || url.protocol == "https:"
+      const url = new URL(trimmedValue)
+      return url.protocol === "http:" || url.protocol === "https:"
     } catch {
       return false
     }
@@ -433,6 +438,7 @@ export class FolksonomyEditorRow extends LitElement {
     const confirmed = confirm(msg("You are about to visit an external website. Continue?"))
     if (!confirmed) {
       e.preventDefault()
+      e.stopPropagation()
     }
   }
 
@@ -504,6 +510,7 @@ export class FolksonomyEditorRow extends LitElement {
                     target="_blank"
                     rel="noopener noreferrer nofollow"
                     @click=${this.confirmExternalNavigation}
+                    @auxclick=${this.confirmExternalNavigation}
                   >
                     ${this.value}
                   </a>

--- a/web-components/src/components/folksonomy/folksonomy-editor-row.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor-row.ts
@@ -424,7 +424,7 @@ export class FolksonomyEditorRow extends LitElement {
     try {
       const url = new URL(value)
       return url.protocol == "http:" || url.protocol == "https:"
-    } catch (err) {
+    } catch {
       return false
     }
   }

--- a/web-components/src/components/folksonomy/folksonomy-editor-row.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor-row.ts
@@ -420,8 +420,13 @@ export class FolksonomyEditorRow extends LitElement {
     `,
   ]
 
-  private isUrl(value: string) {
-    return /^https?:\/\/\S+$/i.test(value)
+  private isUrl(value: string): boolean {
+    try {
+      const url = new URL(value)
+      return url.protocol == "http:" || url.protocol == "https:"
+    } catch (err) {
+      return false
+    }
   }
 
   private confirmExternalNavigation(e: Event) {

--- a/web-components/src/components/folksonomy/folksonomy-editor-row.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor-row.ts
@@ -420,6 +420,17 @@ export class FolksonomyEditorRow extends LitElement {
     `,
   ]
 
+  private isUrl(value: string) {
+    return /^https?:\/\/\S+$/i.test(value)
+  }
+
+  private confirmExternalNavigation(e: Event) {
+    const confirmed = confirm("You are about to visit an external website. Continue?")
+    if (!confirmed) {
+      e.preventDefault()
+    }
+  }
+
   override render() {
     if (this.empty) {
       return html`
@@ -481,7 +492,18 @@ export class FolksonomyEditorRow extends LitElement {
                 .value=${this.tempValue}
                 @input=${this.handleInputChange}
               />`
-            : this.value}
+            : this.isUrl(this.value)
+              ? html`
+                  <a
+                    href=${this.value}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    @click=${this.confirmExternalNavigation}
+                  >
+                    ${this.value}
+                  </a>
+                `
+              : this.value}
         </td>
         ${this.pageType == "edit"
           ? html`<td>

--- a/web-components/src/components/folksonomy/folksonomy-editor-row.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor-row.ts
@@ -430,7 +430,7 @@ export class FolksonomyEditorRow extends LitElement {
   }
 
   private confirmExternalNavigation(e: Event) {
-    const confirmed = confirm("You are about to visit an external website. Continue?")
+    const confirmed = confirm(msg("You are about to visit an external website. Continue?"))
     if (!confirmed) {
       e.preventDefault()
     }
@@ -502,7 +502,7 @@ export class FolksonomyEditorRow extends LitElement {
                   <a
                     href=${this.value}
                     target="_blank"
-                    rel="noopener noreferrer"
+                    rel="noopener noreferrer nofollow"
                     @click=${this.confirmExternalNavigation}
                   >
                     ${this.value}


### PR DESCRIPTION
### What
-  Made URL clickable on the Folksonomy Engine webcomponent (#355 ).

### Screenshot
Before
<img width="1918" height="577" alt="before #355" src="https://github.com/user-attachments/assets/51c65a44-63cf-425f-b71d-2b0e07bc8dc4" />

After
<img width="1918" height="567" alt="after #355" src="https://github.com/user-attachments/assets/cd3e52d3-2cd8-432e-8ce6-d00574ce33cf" />

<img width="1918" height="620" alt="image" src="https://github.com/user-attachments/assets/dca0c783-33e2-4bc4-91f9-cb5c97176b98" />

### Fixes bug(s)
- #355 

### Closes
- #355 