### PR TITLE
fix: resolve dark mode issue in webcomponents (closes #417, closes #418, closes #419)

### DIFF
--- a/web-components/src/components/shared/product-link-button.ts
+++ b/web-components/src/components/shared/product-link-button.ts
@@ -17,6 +17,10 @@ export class ProductLinkButton extends LitElement {
       :host {
         display: inline-block;
       }
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
     `,
   ]
 

--- a/web-components/src/styles/buttons.ts
+++ b/web-components/src/styles/buttons.ts
@@ -130,6 +130,12 @@ export const BUTTON_CLASS_BY_TYPE: Record<ButtonType, CSSResult> = {
     .link-button:hover {
       text-decoration: underline;
     }
+      
+    @media (prefers-color-scheme: dark) {
+      .link-button button {
+        color: white;
+      }
+    }
   `,
   [ButtonType.Success]: css`
     .success-button {

--- a/web-components/src/styles/buttons.ts
+++ b/web-components/src/styles/buttons.ts
@@ -124,17 +124,11 @@ export const BUTTON_CLASS_BY_TYPE: Record<ButtonType, CSSResult> = {
       background-color: transparent;
       border-color: transparent;
       cursor: pointer;
-      color: black;
+      color: inherit;
     }
 
     .link-button:hover {
       text-decoration: underline;
-    }
-      
-    @media (prefers-color-scheme: dark) {
-      .link-button button {
-        color: white;
-      }
     }
   `,
   [ButtonType.Success]: css`


### PR DESCRIPTION
### What

Fix the "View Product" link button text being invisible in dark mode by using CSS color inheritance instead of a hardcoded color: black

---

### Screenshot

in light mode:
<img width="1058" height="566" alt="image" src="https://github.com/user-attachments/assets/c8540d60-69f3-412f-bae1-a6dc6fed159f" />

in dark mode:
<img width="1100" height="619" alt="image" src="https://github.com/user-attachments/assets/2051df57-245d-4e30-9ac9-4b4efc6142ec" />



---

### Fixes bug(s)

- Closes #417  
- Closes #418  
- Closes #419  

---

### Part of

Dark mode improvements across webcomponents