### PR TITLE
refactor: updated assets-images-path to assets-path in off-webcomponent-configuration

### DIFF
--- a/web-components/.storybook/preview.ts
+++ b/web-components/.storybook/preview.ts
@@ -5,9 +5,9 @@ import { setCustomElementsManifest } from "@storybook/web-components-vite"
 import customElements from "../custom-elements.json"
 setCustomElementsManifest(customElements)
 
-import { assetsImagesPath } from "../src/signals/app"
+import { assetsPath } from "../src/signals/app"
 
-assetsImagesPath.set(import.meta.env.BASE_URL + "assets/images")
+assetsPath.set(import.meta.env.BASE_URL + "assets")
 
 const preview: Preview = {
   parameters: {

--- a/web-components/CHANGELOG.md
+++ b/web-components/CHANGELOG.md
@@ -2,118 +2,102 @@
 
 ## [1.16.0](https://github.com/openfoodfacts/openfoodfacts-webcomponents/compare/v1.15.1...v1.16.0) (2026-01-27)
 
-
 ### Features
 
-* view only mode for folksonomy editor ([#396](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/396)) ([abcdcc7](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/abcdcc72a54d9357173e335e23f372964261fad6))
-
+- view only mode for folksonomy editor ([#396](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/396)) ([abcdcc7](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/abcdcc72a54d9357173e335e23f372964261fad6))
 
 ### Bug Fixes
 
-* align donation banner bullet list spacing ([#401](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/401)) ([5631b68](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/5631b6897f40659fc6928a163ae27a995bdbe172))
-* **deps:** bump diff from 8.0.2 to 8.0.3 in /web-components ([#400](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/400)) ([92f97d1](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/92f97d161987bf6e0591da78ec1de3990c684f90))
-* **deps:** bump qs from 6.14.0 to 6.14.1 in /web-components ([#394](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/394)) ([84710f8](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/84710f8a9f2d8863ff5e098e57d6c65f5519b3d1))
+- align donation banner bullet list spacing ([#401](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/401)) ([5631b68](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/5631b6897f40659fc6928a163ae27a995bdbe172))
+- **deps:** bump diff from 8.0.2 to 8.0.3 in /web-components ([#400](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/400)) ([92f97d1](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/92f97d161987bf6e0591da78ec1de3990c684f90))
+- **deps:** bump qs from 6.14.0 to 6.14.1 in /web-components ([#394](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/394)) ([84710f8](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/84710f8a9f2d8863ff5e098e57d6c65f5519b3d1))
 
 ## [1.15.1](https://github.com/openfoodfacts/openfoodfacts-webcomponents/compare/v1.15.0...v1.15.1) (2025-12-04)
 
-
 ### Bug Fixes
 
-* issue [#334](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/334) Round the red line in the donation web components. ([#369](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/369)) ([a2f086a](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/a2f086a464687783d829e1b63986afab2d44b847))
-* Update donation banner to display next year in fundraiser message ([#375](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/375)) ([484053b](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/484053bfc685ac8a4921003a93a8c0a0d472c581))
+- issue [#334](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/334) Round the red line in the donation web components. ([#369](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/369)) ([a2f086a](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/a2f086a464687783d829e1b63986afab2d44b847))
+- Update donation banner to display next year in fundraiser message ([#375](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/375)) ([484053b](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/484053bfc685ac8a4921003a93a8c0a0d472c581))
 
 ## [1.15.0](https://github.com/openfoodfacts/openfoodfacts-webcomponents/compare/v1.14.2...v1.15.0) (2025-10-27)
 
-
 ### Features
 
-* add webcomponents version field to window or globalThis ([#317](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/317)) ([674e451](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/674e4511dad6cee51b104c2e6d99b6ef083487f4))
-* **knowledge-panels:** add top-panels property ([#297](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/297)) ([22c27c2](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/22c27c2d4dd0fc97f387871f5fca055e72ad1020))
-
+- add webcomponents version field to window or globalThis ([#317](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/317)) ([674e451](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/674e4511dad6cee51b104c2e6d99b6ef083487f4))
+- **knowledge-panels:** add top-panels property ([#297](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/297)) ([22c27c2](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/22c27c2d4dd0fc97f387871f5fca055e72ad1020))
 
 ### Bug Fixes
 
-* conditionally include correction and data in annotate calls ([#318](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/318)) ([e48cc93](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/e48cc93e8213a707e618dd14b0b8e7d07717a624))
-* **deps:** bump dompurify from 3.2.6 to 3.2.7 in /web-components ([#311](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/311)) ([280a928](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/280a928540e507592838c5dc04d212f2033dd967))
-* **deps:** bump the interface-libraries group in /web-components with 3 updates ([#201](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/201)) ([4cf80a6](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/4cf80a6accc30a8e9ef442dd5007ee21a1e4122c))
-* typo in readme ([#336](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/336)) ([d03eccc](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/d03eccc4a7761b3d2de695a5209608fda519be3e))
+- conditionally include correction and data in annotate calls ([#318](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/318)) ([e48cc93](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/e48cc93e8213a707e618dd14b0b8e7d07717a624))
+- **deps:** bump dompurify from 3.2.6 to 3.2.7 in /web-components ([#311](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/311)) ([280a928](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/280a928540e507592838c5dc04d212f2033dd967))
+- **deps:** bump the interface-libraries group in /web-components with 3 updates ([#201](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/201)) ([4cf80a6](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/4cf80a6accc30a8e9ef442dd5007ee21a1e4122c))
+- typo in readme ([#336](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/336)) ([d03eccc](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/d03eccc4a7761b3d2de695a5209608fda519be3e))
 
 ## [1.14.2](https://github.com/openfoodfacts/openfoodfacts-webcomponents/compare/v1.14.1...v1.14.2) (2025-09-21)
 
-
 ### Bug Fixes
 
-* Include credentials in all Robotoff API requests ([#306](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/306)) ([8537024](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/85370244af1418f6e95914efe44e163fa02ac36a))
+- Include credentials in all Robotoff API requests ([#306](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/306)) ([8537024](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/85370244af1418f6e95914efe44e163fa02ac36a))
 
 ## [1.14.1](https://github.com/openfoodfacts/openfoodfacts-webcomponents/compare/v1.14.0...v1.14.1) (2025-09-19)
 
-
 ### Bug Fixes
 
-* revert output file name to off-webcomponents.bundled.js ([#303](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/303)) ([84e8af3](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/84e8af312c4f54d98e569c0c6be0d86ffd8f045b))
+- revert output file name to off-webcomponents.bundled.js ([#303](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/303)) ([84e8af3](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/84e8af312c4f54d98e569c0c6be0d86ffd8f045b))
 
 ## [1.14.0](https://github.com/openfoodfacts/openfoodfacts-webcomponents/compare/v1.13.2...v1.14.0) (2025-09-18)
 
-
 ### Features
 
-* transition to Vite, add Storybook ([#274](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/274)) ([f416d9a](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/f416d9ad0d5f73831a818deff96444b790b42e55))
-
+- transition to Vite, add Storybook ([#274](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/274)) ([f416d9a](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/f416d9ad0d5f73831a818deff96444b790b42e55))
 
 ### Bug Fixes
 
-* **deps:** bump marked from 16.2.1 to 16.3.0 in /web-components ([#287](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/287)) ([7169895](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/7169895c94263615653b85ffe7036e92f4dbee27))
-* Type errors, rename getTaxonomyNameByLang and use SDK Nutrient Type ([#273](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/273)) ([2eee761](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/2eee761d4f40b94cee6d6bf1ea1e9ee6f62e17ac))
+- **deps:** bump marked from 16.2.1 to 16.3.0 in /web-components ([#287](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/287)) ([7169895](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/7169895c94263615653b85ffe7036e92f4dbee27))
+- Type errors, rename getTaxonomyNameByLang and use SDK Nutrient Type ([#273](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/273)) ([2eee761](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/2eee761d4f40b94cee6d6bf1ea1e9ee6f62e17ac))
 
 ## [1.13.2](https://github.com/openfoodfacts/openfoodfacts-webcomponents/compare/v1.13.1...v1.13.2) (2025-09-11)
 
-
 ### Bug Fixes
 
-* Robotoff instance creation in robotoff.ts ([#282](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/282)) ([2d8580c](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/2d8580c6358126a9deede0c3b6c1c8a4d6424762)), closes [#281](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/281)
+- Robotoff instance creation in robotoff.ts ([#282](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/282)) ([2d8580c](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/2d8580c6358126a9deede0c3b6c1c8a4d6424762)), closes [#281](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/281)
 
 ## [1.13.1](https://github.com/openfoodfacts/openfoodfacts-webcomponents/compare/v1.13.0...v1.13.1) (2025-09-05)
 
-
 ### Bug Fixes
 
-* fix library publication ([3691141](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/369114137f5ffa7acc68565569463ed92c8e1d4b))
+- fix library publication ([3691141](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/369114137f5ffa7acc68565569463ed92c8e1d4b))
 
 ## [1.13.0](https://github.com/openfoodfacts/openfoodfacts-webcomponents/compare/v1.12.3...v1.13.0) (2025-09-02)
 
-
 ### Features
 
-* add news-feed web component ([#268](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/268)) ([24c80cd](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/24c80cd89d416991a4e4f67cd0db7c4f787bf5b1))
-* adds delete and replace for values and properties ([#264](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/264)) ([3bceb87](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/3bceb871be3aa02a7439eec2f6902847e61dfc9d))
-* Integrate @openfoodfacts/openfoodfacts-nodejs ([#266](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/266)) ([7052f3b](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/7052f3ba3677c1c8393b988bfa79d631521bf968))
-
+- add news-feed web component ([#268](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/268)) ([24c80cd](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/24c80cd89d416991a4e4f67cd0db7c4f787bf5b1))
+- adds delete and replace for values and properties ([#264](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/264)) ([3bceb87](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/3bceb871be3aa02a7439eec2f6902847e61dfc9d))
+- Integrate @openfoodfacts/openfoodfacts-nodejs ([#266](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/266)) ([7052f3b](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/7052f3ba3677c1c8393b988bfa79d631521bf968))
 
 ### Bug Fixes
 
-* fixes the link for properties exploration ([#213](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/213)) ([6385338](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/6385338de1a11a97de8e3b48cac18b121ef80742))
-* Include credentials in robotoff read requests ([#265](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/265)) ([cb52e90](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/cb52e901d5b33bec3d9da750840ca09958512528))
+- fixes the link for properties exploration ([#213](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/213)) ([6385338](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/6385338de1a11a97de8e3b48cac18b121ef80742))
+- Include credentials in robotoff read requests ([#265](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/265)) ([cb52e90](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/cb52e901d5b33bec3d9da750840ca09958512528))
 
 ## [1.12.3](https://github.com/openfoodfacts/openfoodfacts-webcomponents/compare/v1.12.2...v1.12.3) (2025-08-18)
 
-
 ### Bug Fixes
 
-* improve taxonomy name retrieval with better error handling ([#249](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/249)) ([8e24499](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/8e2449911bdfb49e7d9d25158a4990d6b00c481c)), closes [#217](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/217)
+- improve taxonomy name retrieval with better error handling ([#249](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/249)) ([8e24499](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/8e2449911bdfb49e7d9d25158a4990d6b00c481c)), closes [#217](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/217)
 
 ## [1.12.2](https://github.com/openfoodfacts/openfoodfacts-webcomponents/compare/v1.12.1...v1.12.2) (2025-08-17)
 
-
 ### Bug Fixes
 
-* Product card height  inconsistency fixed ([#241](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/241)) ([822ad73](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/822ad73911b10537df8c93b2dd65fd616a550bd0))
+- Product card height inconsistency fixed ([#241](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/241)) ([822ad73](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/822ad73911b10537df8c93b2dd65fd616a550bd0))
 
 ## [1.12.1](https://github.com/openfoodfacts/openfoodfacts-webcomponents/compare/v1.12.0...v1.12.1) (2025-08-15)
 
-
 ### Bug Fixes
 
-* score value type in product card prop ([#235](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/235)) ([eefbcee](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/eefbcee1c866a1c14464880fcac3d92c1a941330))
+- score value type in product card prop ([#235](https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/235)) ([eefbcee](https://github.com/openfoodfacts/openfoodfacts-webcomponents/commit/eefbcee1c866a1c14464880fcac3d92c1a941330))
 
 ## [1.12.0](https://github.com/openfoodfacts/openfoodfacts-webcomponents/compare/v1.11.0...v1.12.0) (2025-08-13)
 
@@ -315,7 +299,7 @@
 ### Added
 
 - Add `donation-banner` web component to show the donation banner in the web components.
-- Add parameter `assets-images-path` to `off-web-components-configuration` to allow to change the path of the assets images.
+- Add parameter `assets-path` to `off-web-components-configuration` to allow to change the path of the assets images.
 - Add `mobile-badges` web component to show the mobile badges in the web components.
 - Update `donation-banner` web component to automatically update the year in the donation banner. And allow to change the year with the `year` property.
 

--- a/web-components/README.md
+++ b/web-components/README.md
@@ -95,7 +95,7 @@ It has this parameters :
   - `img-url` : url of the images of the products
   - `dry-run` : usefull for testing annotations without saving them, default is `false`. It will console.log the annotations instead of sending them to the api.
 - `language-code` : language code of the user, default is `en`
-- `assets-images-path` : path of the images in assets/images folder, default is `/assets/images`
+- `assets-path` : path of the images in assets/images folder, default is `/assets`
 
 The default configuration is :
 
@@ -107,7 +107,7 @@ The default configuration is :
           "apiUrl": "https://robotoff.openfoodfacts.net/api/v1",
           "imgUrl": "https://images.openfoodfacts.net/images/products"
         }'
-  assets-images-path="/assets/images"
+  assets-path="/assets"
 ></off-webcomponents-configuration>
 <off-boolean-attribute></off-boolean-attribute>
 ```

--- a/web-components/src/components/shared/off-webcomponents-configuration.ts
+++ b/web-components/src/components/shared/off-webcomponents-configuration.ts
@@ -1,7 +1,7 @@
 import { robotoffConfiguration } from "../../signals/robotoff"
 import { folksonomyConfiguration } from "../../signals/folksonomy"
 import {
-  DEFAULT_ASSETS_IMAGES_PATH,
+  DEFAULT_ASSETS_PATH,
   DEFAULT_LANGUAGE_CODE,
   DEFAULT_ROBOTOFF_CONFIGURATION,
   DEFAULT_FOLKSONOMY_CONFIGURATION,
@@ -12,7 +12,7 @@ import type { OffWebcomponentConfigurationOptions } from "../../types"
 import type { RobotoffConfigurationOptions } from "../../types/robotoff"
 import type { FolksonomyConfigurationOptions } from "../../types/folksonomy"
 import { setLanguageCode } from "../../localization"
-import { assetsImagesPath, countryCode } from "../../signals/app"
+import { assetsPath, countryCode } from "../../signals/app"
 import { DEFAULT_OPENFOODFACTS_API_URL, openfoodfactsApiUrl } from "../../signals/openfoodfacts"
 
 /**
@@ -52,10 +52,10 @@ const CONFIGURATION_PROPERTIES: Record<
       countryCode.set(value)
     },
   },
-  "assets-images-path": {
-    propertyName: "assetsImagesPath",
+  "assets-path": {
+    propertyName: "assetsPath",
     fn: (value: string) => {
-      assetsImagesPath.set(value)
+      assetsPath.set(value)
     },
   },
   "folksonomy-configuration": {
@@ -111,8 +111,8 @@ export class OffWebcomponentsConfiguration extends LitElement {
    * The image path we need to use to retrieve the images in assets/images folder.
    * @attr image-path
    */
-  @property({ type: String, attribute: "assets-images-path", reflect: true })
-  assetsImagesPath?: string = DEFAULT_ASSETS_IMAGES_PATH
+  @property({ type: String, attribute: "assets-path", reflect: true })
+  assetsPath?: string = DEFAULT_ASSETS_PATH
 
   /**
    * The folksonomy configuration object.

--- a/web-components/src/constants.ts
+++ b/web-components/src/constants.ts
@@ -43,7 +43,7 @@ export enum EventState {
   ERROR = "error", // an error occurred during annotation
 }
 
-export const DEFAULT_ASSETS_IMAGES_PATH = "/assets/images"
+export const DEFAULT_ASSETS_PATH = "/assets"
 
 export const SELECT_ICON_FILE_NAME = "carret-bottom.svg"
 export const WHITE_SELECT_ICON_FILE_NAME = "white-carret-bottom.svg"

--- a/web-components/src/signals/app.test.ts
+++ b/web-components/src/signals/app.test.ts
@@ -1,108 +1,104 @@
 import { describe, it, expect, beforeEach } from "vitest"
-import { assetsImagesPath, getImageUrl, countryCode, languageCode } from "../signals/app"
-import {
-  DEFAULT_ASSETS_IMAGES_PATH,
-  DEFAULT_COUNTRY_CODE,
-  DEFAULT_LANGUAGE_CODE,
-} from "../constants"
+import { assetsPath, getImageUrl, countryCode, languageCode } from "../signals/app"
+import { DEFAULT_ASSETS_PATH, DEFAULT_COUNTRY_CODE, DEFAULT_LANGUAGE_CODE } from "../constants"
 
 describe("App Signals", () => {
   beforeEach(() => {
     // Reset signals to default values
-    assetsImagesPath.set(DEFAULT_ASSETS_IMAGES_PATH)
+    assetsPath.set(DEFAULT_ASSETS_PATH)
     countryCode.set(DEFAULT_COUNTRY_CODE)
     languageCode.set(DEFAULT_LANGUAGE_CODE)
   })
 
-  describe("assetsImagesPath signal", () => {
+  describe("assetsPath signal", () => {
     it("should have default value", () => {
-      expect(assetsImagesPath.get()).toBe(DEFAULT_ASSETS_IMAGES_PATH)
+      expect(assetsPath.get()).toBe(DEFAULT_ASSETS_PATH)
     })
 
     it("should be reactive to changes", () => {
       const newPath = "/custom/assets/path"
-      assetsImagesPath.set(newPath)
-      expect(assetsImagesPath.get()).toBe(newPath)
+      assetsPath.set(newPath)
+      expect(assetsPath.get()).toBe(newPath)
     })
 
     it("should handle empty string", () => {
-      assetsImagesPath.set("")
-      expect(assetsImagesPath.get()).toBe("")
+      assetsPath.set("")
+      expect(assetsPath.get()).toBe("")
     })
 
     it("should handle paths with trailing slashes", () => {
       const pathWithSlash = "/assets/images/"
-      assetsImagesPath.set(pathWithSlash)
-      expect(assetsImagesPath.get()).toBe(pathWithSlash)
+      assetsPath.set(pathWithSlash)
+      expect(assetsPath.get()).toBe(pathWithSlash)
     })
 
     it("should handle relative paths", () => {
       const relativePath = "../assets/images"
-      assetsImagesPath.set(relativePath)
-      expect(assetsImagesPath.get()).toBe(relativePath)
+      assetsPath.set(relativePath)
+      expect(assetsPath.get()).toBe(relativePath)
     })
 
     it("should handle absolute URLs", () => {
       const absoluteUrl = "https://cdn.example.com/assets"
-      assetsImagesPath.set(absoluteUrl)
-      expect(assetsImagesPath.get()).toBe(absoluteUrl)
+      assetsPath.set(absoluteUrl)
+      expect(assetsPath.get()).toBe(absoluteUrl)
     })
   })
 
   describe("getImageUrl function", () => {
     it("should combine assets path with file name", () => {
       const fileName = "logo.svg"
-      const expected = `${DEFAULT_ASSETS_IMAGES_PATH}/${fileName}`
+      const expected = `${DEFAULT_ASSETS_PATH}/${fileName}`
       expect(getImageUrl(fileName)).toBe(expected)
     })
 
-    it("should react to changes in assetsImagesPath", () => {
+    it("should react to changes in assetsPath", () => {
       const customPath = "/custom/path"
       const fileName = "icon.png"
 
-      assetsImagesPath.set(customPath)
+      assetsPath.set(customPath)
 
       expect(getImageUrl(fileName)).toBe(`${customPath}/${fileName}`)
     })
 
     it("should handle empty file names", () => {
-      expect(getImageUrl("")).toBe(`${DEFAULT_ASSETS_IMAGES_PATH}/`)
+      expect(getImageUrl("")).toBe(`${DEFAULT_ASSETS_PATH}/`)
     })
 
     it("should handle file names with extensions", () => {
       const fileName = "image.jpg"
-      expect(getImageUrl(fileName)).toBe(`${DEFAULT_ASSETS_IMAGES_PATH}/${fileName}`)
+      expect(getImageUrl(fileName)).toBe(`${DEFAULT_ASSETS_PATH}/${fileName}`)
     })
 
     it("should handle file names without extensions", () => {
       const fileName = "image"
-      expect(getImageUrl(fileName)).toBe(`${DEFAULT_ASSETS_IMAGES_PATH}/${fileName}`)
+      expect(getImageUrl(fileName)).toBe(`${DEFAULT_ASSETS_PATH}/${fileName}`)
     })
 
     it("should handle file names with paths", () => {
       const fileName = "icons/arrow.svg"
-      expect(getImageUrl(fileName)).toBe(`${DEFAULT_ASSETS_IMAGES_PATH}/${fileName}`)
+      expect(getImageUrl(fileName)).toBe(`${DEFAULT_ASSETS_PATH}/${fileName}`)
     })
 
     it("should handle file names with special characters", () => {
       const fileName = "image with spaces & symbols.png"
-      expect(getImageUrl(fileName)).toBe(`${DEFAULT_ASSETS_IMAGES_PATH}/${fileName}`)
+      expect(getImageUrl(fileName)).toBe(`${DEFAULT_ASSETS_PATH}/${fileName}`)
     })
 
     it("should handle assets path without trailing slash", () => {
-      assetsImagesPath.set("/assets")
+      assetsPath.set("/assets")
       const fileName = "image.png"
       expect(getImageUrl(fileName)).toBe("/assets/image.png")
     })
 
     it("should handle assets path with trailing slash", () => {
-      assetsImagesPath.set("/assets/")
+      assetsPath.set("/assets/")
       const fileName = "image.png"
       expect(getImageUrl(fileName)).toBe("/assets//image.png") // Double slash - might be a bug in implementation
     })
 
     it("should work with CDN URLs", () => {
-      assetsImagesPath.set("https://cdn.example.com/assets")
+      assetsPath.set("https://cdn.example.com/assets")
       const fileName = "logo.svg"
       expect(getImageUrl(fileName)).toBe("https://cdn.example.com/assets/logo.svg")
     })
@@ -195,11 +191,11 @@ describe("App Signals", () => {
       const newCountry = "jp"
       const newLanguage = "ja"
 
-      assetsImagesPath.set(newAssetsPath)
+      assetsPath.set(newAssetsPath)
       countryCode.set(newCountry)
       languageCode.set(newLanguage)
 
-      expect(assetsImagesPath.get()).toBe(newAssetsPath)
+      expect(assetsPath.get()).toBe(newAssetsPath)
       expect(countryCode.get()).toBe(newCountry)
       expect(languageCode.get()).toBe(newLanguage)
     })
@@ -215,15 +211,15 @@ describe("App Signals", () => {
 
     it("should maintain consistency during concurrent-like operations", () => {
       // Simulate rapid changes to different signals
-      assetsImagesPath.set("/path1")
+      assetsPath.set("/path1")
       countryCode.set("country1")
       languageCode.set("lang1")
 
-      assetsImagesPath.set("/path2")
+      assetsPath.set("/path2")
       countryCode.set("country2")
       languageCode.set("lang2")
 
-      expect(assetsImagesPath.get()).toBe("/path2")
+      expect(assetsPath.get()).toBe("/path2")
       expect(countryCode.get()).toBe("country2")
       expect(languageCode.get()).toBe("lang2")
     })
@@ -235,11 +231,11 @@ describe("App Signals", () => {
       const longCountry = "x".repeat(1000)
       const longLanguage = "y".repeat(1000)
 
-      assetsImagesPath.set(longPath)
+      assetsPath.set(longPath)
       countryCode.set(longCountry)
       languageCode.set(longLanguage)
 
-      expect(assetsImagesPath.get()).toBe(longPath)
+      expect(assetsPath.get()).toBe(longPath)
       expect(countryCode.get()).toBe(longCountry)
       expect(languageCode.get()).toBe(longLanguage)
     })
@@ -249,31 +245,31 @@ describe("App Signals", () => {
       const specialCountry = "测试"
       const specialLanguage = "español"
 
-      assetsImagesPath.set(specialPath)
+      assetsPath.set(specialPath)
       countryCode.set(specialCountry)
       languageCode.set(specialLanguage)
 
-      expect(assetsImagesPath.get()).toBe(specialPath)
+      expect(assetsPath.get()).toBe(specialPath)
       expect(countryCode.get()).toBe(specialCountry)
       expect(languageCode.get()).toBe(specialLanguage)
     })
 
     it("should handle numeric-like strings", () => {
-      assetsImagesPath.set("123456")
+      assetsPath.set("123456")
       countryCode.set("42")
       languageCode.set("99")
 
-      expect(assetsImagesPath.get()).toBe("123456")
+      expect(assetsPath.get()).toBe("123456")
       expect(countryCode.get()).toBe("42")
       expect(languageCode.get()).toBe("99")
     })
 
     it("should handle boolean-like strings", () => {
-      assetsImagesPath.set("true")
+      assetsPath.set("true")
       countryCode.set("false")
       languageCode.set("undefined")
 
-      expect(assetsImagesPath.get()).toBe("true")
+      expect(assetsPath.get()).toBe("true")
       expect(countryCode.get()).toBe("false")
       expect(languageCode.get()).toBe("undefined")
     })
@@ -281,24 +277,24 @@ describe("App Signals", () => {
 
   describe("constants integration", () => {
     it("should use correct default constants", () => {
-      expect(DEFAULT_ASSETS_IMAGES_PATH).toBe("/assets/images")
+      expect(DEFAULT_ASSETS_PATH).toBe("/assets/images")
       expect(DEFAULT_COUNTRY_CODE).toBe("fr")
       expect(DEFAULT_LANGUAGE_CODE).toBe("en")
     })
 
     it("should respect defaults after reset", () => {
       // Change values
-      assetsImagesPath.set("/custom")
+      assetsPath.set("/custom")
       countryCode.set("us")
       languageCode.set("es")
 
       // Reset to defaults
-      assetsImagesPath.set(DEFAULT_ASSETS_IMAGES_PATH)
+      assetsPath.set(DEFAULT_ASSETS_PATH)
       countryCode.set(DEFAULT_COUNTRY_CODE)
       languageCode.set(DEFAULT_LANGUAGE_CODE)
 
       // Verify defaults are restored
-      expect(assetsImagesPath.get()).toBe(DEFAULT_ASSETS_IMAGES_PATH)
+      expect(assetsPath.get()).toBe(DEFAULT_ASSETS_PATH)
       expect(countryCode.get()).toBe(DEFAULT_COUNTRY_CODE)
       expect(languageCode.get()).toBe(DEFAULT_LANGUAGE_CODE)
     })

--- a/web-components/src/signals/app.ts
+++ b/web-components/src/signals/app.ts
@@ -1,14 +1,10 @@
 import { signal } from "@lit-labs/signals"
-import {
-  DEFAULT_ASSETS_IMAGES_PATH,
-  DEFAULT_COUNTRY_CODE,
-  DEFAULT_LANGUAGE_CODE,
-} from "../constants"
+import { DEFAULT_ASSETS_PATH, DEFAULT_COUNTRY_CODE, DEFAULT_LANGUAGE_CODE } from "../constants"
 
-export const assetsImagesPath = signal(DEFAULT_ASSETS_IMAGES_PATH)
+export const assetsPath = signal(DEFAULT_ASSETS_PATH)
 
 export const getImageUrl = (fileName: string) => {
-  return `${assetsImagesPath.get()}/${fileName}`
+  return `${assetsPath.get()}/images/${fileName}`
 }
 
 export const countryCode = signal(DEFAULT_COUNTRY_CODE)

--- a/web-components/src/types/index.ts
+++ b/web-components/src/types/index.ts
@@ -6,7 +6,7 @@ export type OffWebcomponentConfigurationOptions = {
   robotoffConfiguration: RobotoffConfigurationOptions
   languageCode: string
   countryCode: string
-  assetsImagesPath: string
+  assetsPath: string
   folksonomyConfiguration: FolksonomyConfigurationOptions
   openfoodfactsApiUrl: string
 }


### PR DESCRIPTION
### What
- Updated assets-images-path to assets-path in off-webcomponent-configuration #179 . Earlier the asset path was hardcoded as  "/assets/images" , now it is updated as "/assets". The getImageUrl() now fetches from "${assetPath}/images/${filename}". Also updated the readme for the same.

### Screenshot
<img width="1919" height="693" alt="image" src="https://github.com/user-attachments/assets/58cec47a-cdd2-4769-8791-5a0f19b0ac2e" />

### Fixes bug(s)
- #179 

### Part of 
- #179 
