### PR TITLE
fix: #440 Ingredients-spellcheck is not listed in storybook components, frontend.

### DIFF
--- a/web-components/src/components/robotoff-ingredient-spellcheck/robotoff-ingredient-spellcheck.stories.ts
+++ b/web-components/src/components/robotoff-ingredient-spellcheck/robotoff-ingredient-spellcheck.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/web-components-vite"
+import "./robotoff-ingredient-spellcheck"
+
+const meta: Meta = {
+  title: "Components/Robotoff/Ingredient Spellcheck",
+  component: "robotoff-ingredient-spellcheck",
+  parameters: {
+    layout: "centered",
+  },
+}
+export default meta
+
+type Story = StoryObj
+
+export const Basic: Story = {
+  args: {},
+}


### PR DESCRIPTION

### What
- Added Ingredients-spellcheck to storybook -> components list.
- 
### Screenshot

Before:
<img width="374" height="942" alt="image" src="https://github.com/user-attachments/assets/9dd786fb-b870-4b37-8279-b951abaafeba" />

After:
<img width="1917" height="799" alt="image" src="https://github.com/user-attachments/assets/45f76955-7258-48e5-98eb-0a38dceb258e" />

### Fixes bug(s)
- #440 
