### PR TITLE
feat: Made date visible on nutrition images

### DIFF
--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -113,6 +113,9 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
   @state()
   private nutrimentsData?: NutrimentsProductType
 
+  @state()
+  private uploaded_Date: string = ""
+
   get currentInsightId() {
     return this.insightsIds[this.currentInsightIndex]
   }
@@ -182,12 +185,26 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
   async getProductNutriments(productCode: string) {
     this.nutrimentsData = undefined
     const result = await fetchProduct<NutrimentsProductType>(productCode, {
-      fields: [ProductFields.NUTRIMENTS],
+      fields: [ProductFields.NUTRIMENTS, ProductFields.IMAGES],
       lc: languageCode.get(),
     })
     this.nutrimentsData = result.product
+    const images = result?.product?.images
+    const key = images["nutrition_en"]?.imgid
+    const uploaded_t = key ? images[key]?.uploaded_t : undefined
+
+    this.uploaded_Date = this.getUploadedTime(uploaded_t)
     return result.product.nutriments
   }
+
+  getUploadedTime = (data: number | undefined) =>
+    data
+      ? new Date(data * 1000).toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        })
+      : ""
 
   renderImage(insight: NutrientsInsight) {
     if (!insight?.source_image) {
@@ -196,6 +213,7 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     const imgUrl = getRobotoffImageUrl(insight.source_image)
     return html`
       <div class="image-wrapper">
+        <span>${this.uploaded_Date ? this.uploaded_Date : ""}</span>
         <zoomable-image
           src=${imgUrl}
           .size="${{

--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -60,6 +60,7 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
         z-index: 1;
         top: 1rem;
         display: flex;
+        flex-direction: column;
         align-items: center;
         margin-bottom: 1rem;
         background-color: white;
@@ -71,6 +72,12 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
         box-sizing: border-box;
         max-width: ${IMAGE_MAX_WIDTH}px;
         width: 100%;
+      }
+
+      .date {
+        padding-top: 15px;
+        font-size: medium;
+        font-weight: 500;
       }
 
       .nutrients {
@@ -213,7 +220,7 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     const imgUrl = getRobotoffImageUrl(insight.source_image)
     return html`
       <div class="image-wrapper">
-        <span>${this.uploaded_Date ? this.uploaded_Date : ""}</span>
+        <div class="date">${this.uploaded_Date ? this.uploaded_Date : ""}</div>
         <zoomable-image
           src=${imgUrl}
           .size="${{

--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -20,7 +20,7 @@ import {
 import { BASE } from "../../styles/base"
 import { getRobotoffImageUrl } from "../../signals/robotoff"
 import { ButtonType, getButtonClasses } from "../../styles/buttons"
-import { FLEX } from "../../styles/utils"
+import { FLEX, RELATIVE } from "../../styles/utils"
 import { EventState, EventType } from "../../constants"
 import type { BasicStateEventDetail } from "../../types"
 import type { NutrimentsProductType } from "../../types/openfoodfacts"
@@ -35,6 +35,11 @@ import { CountryCodeMixin } from "../../mixins/country-codes-mixin"
 import { DisplayProductLinkMixin } from "../../mixins/display-product-link-mixin"
 import { localized, msg } from "@lit/localize"
 import { languageCode } from "../../signals/app"
+import { clickOutside } from "../../directives/click-outside"
+import "../shared/info-button"
+import { POPOVER } from "../../styles/popover"
+import { darkModeListener } from "../../utils/dark-mode-listener"
+import { classMap } from "lit-html/directives/class-map.js"
 
 const IMAGE_MAX_WIDTH = 700
 /**
@@ -50,9 +55,26 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     CountryCodeMixin(LoadingWithTimeoutMixin(LitElement, undefined as AnnotationAnswer | undefined))
   )
 ) {
+  isDarkMode = darkModeListener.darkMode
+  private _darkModeCb = (isDark: boolean) => {
+    this.isDarkMode = isDark
+    this.requestUpdate()
+  }
+
+  override connectedCallback() {
+    super.connectedCallback()
+    darkModeListener.subscribe(this._darkModeCb)
+  }
+
+  override disconnectedCallback() {
+    darkModeListener.unsubscribe(this._darkModeCb)
+    super.disconnectedCallback()
+  }
   static override styles = [
     BASE,
     FLEX,
+    POPOVER,
+    RELATIVE,
     ...getButtonClasses([ButtonType.LINK]),
     css`
       .image-wrapper {
@@ -101,6 +123,39 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
       .nutrients product-link-button {
         margin-bottom: 1rem;
       }
+
+      .info-popover {
+        z-index: 2;
+        min-width: 200px;
+      }
+
+      .info-button-wrapper {
+        display: flex-start;
+        position: absolute;
+      }
+
+      .relative {
+        position: relative;
+        margin-top: 6px;
+        margin-bottom: 4px;
+        display: flex;
+        align-items: start;
+        justify-content: end;
+        width: 100%;
+        right: 1px;
+        top: 1px;
+        z-index: 10;
+      }
+
+      .dark-mode {
+        background-color: #1e1e1e;
+        color: #ffffff;
+        border: 1px solid #333;
+      }
+
+      .dark-mode .popover-content {
+        background-color: #1e1e1e;
+      }
     `,
   ]
 
@@ -122,6 +177,9 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
 
   @state()
   private uploaded_Date: string = ""
+
+  @state()
+  showInfoPopover: boolean = false
 
   get currentInsightId() {
     return this.insightsIds[this.currentInsightIndex]
@@ -204,6 +262,20 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     return result.product.nutriments
   }
 
+  /**
+   * Toggles the info popover.
+   */
+  toggleInfoPopover() {
+    this.showInfoPopover = !this.showInfoPopover
+  }
+
+  /**
+   * Closes the info popover.
+   */
+  closeInfoPopover() {
+    this.showInfoPopover = false
+  }
+
   getUploadedTime = (data: number | undefined) =>
     data
       ? new Date(data * 1000).toLocaleDateString(undefined, {
@@ -220,9 +292,15 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     const imgUrl = getRobotoffImageUrl(insight.source_image)
     return html`
       <div class="image-wrapper">
-        <div class="date">${this.uploaded_Date ? this.uploaded_Date : ""}</div>
+        <div class="relative">
+          <div class="info-button-wrapper">
+            <info-button @click=${this.toggleInfoPopover} size="sm"></info-button>
+            ${this.renderInfoPopover()}
+          </div>
+        </div>
         <zoomable-image
           src=${imgUrl}
+          customClass="justify-start"
           .size="${{
             height: "35vh",
             width: "100%",
@@ -230,6 +308,39 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
           }}"
           show-buttons
         ></zoomable-image>
+      </div>
+    `
+  }
+
+  /**
+   * Renders the info popover.
+   * @returns {TemplateResult} The rendered info popover.
+   */
+  renderInfoPopover() {
+    if (!this.showInfoPopover) {
+      return nothing
+    }
+    return html`
+      <div
+        class=${classMap({
+          popover: true,
+          "info-popover": true,
+          "dark-mode": this.isDarkMode,
+        })}
+        ${clickOutside(() => this.closeInfoPopover())}
+      >
+        <div class="popover-right popover-content">
+          ${msg(html`
+            <div>
+              ${this.uploaded_Date
+                ? html`Image uploaded on <br />
+                    <span style="margin-top:4px;">
+                      <em> ${this.uploaded_Date}</em>
+                    </span> `
+                : html`No information available`}
+            </div>
+          `)}
+        </div>
       </div>
     `
   }

--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -38,7 +38,6 @@ import { languageCode } from "../../signals/app"
 import { clickOutside } from "../../directives/click-outside"
 import "../shared/info-button"
 import { POPOVER } from "../../styles/popover"
-import { darkModeListener } from "../../utils/dark-mode-listener"
 import { classMap } from "lit-html/directives/class-map.js"
 
 const IMAGE_MAX_WIDTH = 700
@@ -55,21 +54,6 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     CountryCodeMixin(LoadingWithTimeoutMixin(LitElement, undefined as AnnotationAnswer | undefined))
   )
 ) {
-  isDarkMode = darkModeListener.darkMode
-  private _darkModeCb = (isDark: boolean) => {
-    this.isDarkMode = isDark
-    this.requestUpdate()
-  }
-
-  override connectedCallback() {
-    super.connectedCallback()
-    darkModeListener.subscribe(this._darkModeCb)
-  }
-
-  override disconnectedCallback() {
-    darkModeListener.unsubscribe(this._darkModeCb)
-    super.disconnectedCallback()
-  }
   static override styles = [
     BASE,
     FLEX,
@@ -94,12 +78,6 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
         box-sizing: border-box;
         max-width: ${IMAGE_MAX_WIDTH}px;
         width: 100%;
-      }
-
-      .date {
-        padding-top: 15px;
-        font-size: medium;
-        font-weight: 500;
       }
 
       .nutrients {
@@ -130,7 +108,8 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
       }
 
       .info-button-wrapper {
-        display: flex-start;
+        display: flex;
+        justify-content: flex-start;
         position: absolute;
       }
 
@@ -145,16 +124,6 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
         right: 1px;
         top: 1px;
         z-index: 10;
-      }
-
-      .dark-mode {
-        background-color: #1e1e1e;
-        color: #ffffff;
-        border: 1px solid #333;
-      }
-
-      .dark-mode .popover-content {
-        background-color: #1e1e1e;
       }
     `,
   ]
@@ -176,7 +145,7 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
   private nutrimentsData?: NutrimentsProductType
 
   @state()
-  private uploaded_Date: string = ""
+  private uploadedDate: string = ""
 
   @state()
   showInfoPopover: boolean = false
@@ -255,10 +224,11 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     })
     this.nutrimentsData = result.product
     const images = result?.product?.images
-    const key = images["nutrition_en"]?.imgid
-    const uploaded_t = key ? images[key]?.uploaded_t : undefined
+    const nutritionImage = images?.["nutrition_en"]
+    const key = nutritionImage?.imgid !== undefined ? String(nutritionImage.imgid) : undefined
+    const uploaded_t = key ? images?.[key]?.uploaded_t : undefined
 
-    this.uploaded_Date = this.getUploadedTime(uploaded_t)
+    this.uploadedDate = this.getUploadedTime(uploaded_t)
     return result.product.nutriments
   }
 
@@ -325,17 +295,16 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
         class=${classMap({
           popover: true,
           "info-popover": true,
-          "dark-mode": this.isDarkMode,
         })}
         ${clickOutside(() => this.closeInfoPopover())}
       >
         <div class="popover-right popover-content">
           ${msg(html`
             <div>
-              ${this.uploaded_Date
+              ${this.uploadedDate
                 ? html`Image uploaded on <br />
                     <span style="margin-top:4px;">
-                      <em> ${this.uploaded_Date}</em>
+                      <em> ${this.uploadedDate}</em>
                     </span> `
                 : html`No information available`}
             </div>

--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -207,6 +207,7 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
       return
     }
     this.currentInsightIndex = index
+    this.showInfoPopover = false
     const insight = this.currentInsight
     const data = await this.getProductNutriments(insight.barcode)
 

--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -145,7 +145,7 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
   private nutrimentsData?: NutrimentsProductType
 
   @state()
-  private uploadedDate: string = ""
+  private uploadedDate: string | undefined
 
   @state()
   showInfoPopover: boolean = false
@@ -208,7 +208,10 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     }
     this.currentInsightIndex = index
     const insight = this.currentInsight
-    await this.getProductNutriments(insight.barcode)
+    const data = await this.getProductNutriments(insight.barcode)
+
+    this.nutrimentsData = data?.product
+    this.uploadedDate = data?.uploadedDate
   }
 
   /**
@@ -217,22 +220,26 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
    * @returns {Promise<NutrimentsProductType>}
    */
   async getProductNutriments(productCode: string) {
-    this.nutrimentsData = undefined
     const result = await fetchProduct<NutrimentsProductType>(productCode, {
       fields: [ProductFields.NUTRIMENTS, ProductFields.IMAGES],
       lc: languageCode.get(),
     })
-    this.nutrimentsData = result.product
+
     const images = result?.product?.images
+
     const nutritionImage =
       images?.[`nutrition_${languageCode.get()}`] ??
       images?.nutrition ??
       Object.entries(images ?? {}).find(([key]) => key.startsWith("nutrition_"))?.[1]
+
     const key = nutritionImage?.imgid !== undefined ? String(nutritionImage.imgid) : undefined
+
     const uploaded_t = key ? images?.[key]?.uploaded_t : undefined
 
-    this.uploadedDate = this.getUploadedTime(uploaded_t)
-    return result.product.nutriments
+    return {
+      product: result.product,
+      uploadedDate: this.getUploadedTime(uploaded_t),
+    }
   }
 
   /**
@@ -249,14 +256,15 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     this.showInfoPopover = false
   }
 
-  getUploadedTime = (data: number | undefined) =>
-    data
-      ? new Date(data * 1000).toLocaleDateString(undefined, {
-          year: "numeric",
-          month: "short",
-          day: "numeric",
-        })
-      : ""
+  getUploadedTime = (data: number | undefined) => {
+    if (!data) return undefined
+
+    return new Date(data * 1000).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    })
+  }
 
   renderImage(insight: NutrientsInsight) {
     if (!insight?.source_image) {
@@ -381,7 +389,7 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
               ${this.renderImage(insight as NutrientsInsight)}
               <robotoff-nutrient-extraction-form
                 loading=${ifDefined(this.loading) as AnnotationAnswer}
-                .nutrimentsData="${this.nutrimentsData}"
+                .nutrimentsData="${this.nutrimentsData?.nutriments}"
                 .insight="${insight as NutrientsInsight}"
                 @submit="${this.onSubmit}"
                 @refuse="${this.onRefuse}"

--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -224,7 +224,10 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     })
     this.nutrimentsData = result.product
     const images = result?.product?.images
-    const nutritionImage = images?.["nutrition_en"]
+    const nutritionImage =
+      images?.[`nutrition_${languageCode.get()}`] ??
+      images?.nutrition ??
+      Object.entries(images ?? {}).find(([key]) => key.startsWith("nutrition_"))?.[1]
     const key = nutritionImage?.imgid !== undefined ? String(nutritionImage.imgid) : undefined
     const uploaded_t = key ? images?.[key]?.uploaded_t : undefined
 
@@ -295,20 +298,21 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
         class=${classMap({
           popover: true,
           "info-popover": true,
+          "popover-right": true,
         })}
         ${clickOutside(() => this.closeInfoPopover())}
       >
-        <div class="popover-right popover-content">
-          ${msg(html`
-            <div>
-              ${this.uploadedDate
-                ? html`Image uploaded on <br />
-                    <span style="margin-top:4px;">
-                      <em> ${this.uploadedDate}</em>
-                    </span> `
-                : html`No information available`}
-            </div>
-          `)}
+        <div class="popover-content">
+          <div>
+            ${this.uploadedDate
+              ? html`
+                  ${msg("Image uploaded on")}<br />
+                  <span style="margin-top:4px;">
+                    <em>${this.uploadedDate}</em>
+                  </span>
+                `
+              : msg("No information available")}
+          </div>
         </div>
       </div>
     `

--- a/web-components/src/components/shared/info-button.ts
+++ b/web-components/src/components/shared/info-button.ts
@@ -1,6 +1,6 @@
 import { css, LitElement } from "lit"
 import { html } from "lit-html"
-import { customElement } from "lit/decorators.js"
+import { customElement, property } from "lit/decorators.js"
 import { SAFE_BLUE } from "../../utils/colors"
 import "../icons/info"
 import { Breakpoints } from "../../utils/breakpoints"
@@ -10,6 +10,8 @@ import { Breakpoints } from "../../utils/breakpoints"
  */
 @customElement("info-button")
 export class InfoButton extends LitElement {
+  @property({ type: String })
+  size: "sm" | "" = ""
   static override styles = css`
     .info-button {
       display: flex;
@@ -30,6 +32,13 @@ export class InfoButton extends LitElement {
         padding: 8px;
       }
     }
+
+    .sm {
+      width: 30px;
+      height: 30px;
+      padding: 5px;
+    }
+
     button:hover {
       opacity: 0.8;
     }
@@ -37,7 +46,7 @@ export class InfoButton extends LitElement {
 
   override render() {
     return html`
-      <button class="info-button">
+      <button class="info-button ${this.size ? this.size : ""}">
         <info-icon .custom-styles="${{ fill: "white" }}"></info-icon>
       </button>
     `

--- a/web-components/src/components/shared/info-button.ts
+++ b/web-components/src/components/shared/info-button.ts
@@ -12,6 +12,10 @@ import { Breakpoints } from "../../utils/breakpoints"
 export class InfoButton extends LitElement {
   @property({ type: String })
   size: "sm" | "" = ""
+
+  @property({ type: String, attribute: "aria-label" })
+  ariaLabel = "More information"
+
   static override styles = css`
     .info-button {
       display: flex;
@@ -46,7 +50,11 @@ export class InfoButton extends LitElement {
 
   override render() {
     return html`
-      <button type="button" class="info-button ${this.size ? this.size : ""}">
+      <button
+        type="button"
+        aria-label=${this.ariaLabel}
+        class="info-button ${this.size ? this.size : ""}"
+      >
         <info-icon .custom-styles="${{ fill: "white" }}"></info-icon>
       </button>
     `

--- a/web-components/src/components/shared/info-button.ts
+++ b/web-components/src/components/shared/info-button.ts
@@ -46,7 +46,7 @@ export class InfoButton extends LitElement {
 
   override render() {
     return html`
-      <button class="info-button ${this.size ? this.size : ""}">
+      <button type="button" class="info-button ${this.size ? this.size : ""}">
         <info-icon .custom-styles="${{ fill: "white" }}"></info-icon>
       </button>
     `

--- a/web-components/src/components/shared/zoomable-image.ts
+++ b/web-components/src/components/shared/zoomable-image.ts
@@ -173,6 +173,9 @@ export class ZoomableImage extends MessageDisplayMixinElement {
     this.resetRotatation()
   }
 
+  @property({ type: String })
+  customClass = ""
+
   @state()
   private _rotation = 0
 
@@ -909,7 +912,11 @@ export class ZoomableImage extends MessageDisplayMixinElement {
     }
 
     return html`
-      <div class="toolbar flex justify-end" role="toolbar" aria-label=${msg("Image controls")}>
+      <div
+        class="toolbar flex ${this.customClass != "" ? this.customClass : "justify-end"}"
+        role="toolbar"
+        aria-label=${msg("Image controls")}
+      >
         ${this.renderMobileCanvasToggle()} ${this.renderCenterButton()}
         ${this.renderRotateButtons()}
       </div>

--- a/web-components/src/components/shared/zoomable-image.ts
+++ b/web-components/src/components/shared/zoomable-image.ts
@@ -913,7 +913,7 @@ export class ZoomableImage extends MessageDisplayMixinElement {
 
     return html`
       <div
-        class="toolbar flex ${this.customClass != "" ? this.customClass : "justify-end"}"
+        class="toolbar flex ${this.customClass !== "" ? this.customClass : "justify-end"}"
         role="toolbar"
         aria-label=${msg("Image controls")}
       >

--- a/web-components/src/styles/popover.ts
+++ b/web-components/src/styles/popover.ts
@@ -124,4 +124,28 @@ export const POPOVER = css`
   .popover .button {
     display: flex;
   }
+
+  @media (prefers-color-scheme: dark) {
+    .popover {
+      background-color: #1e1e1e;
+      color: #ffffff;
+      border: 1px solid #333;
+    }
+
+    .popover::before {
+      border-bottom-color: #333;
+    }
+
+    .popover::after {
+      border-bottom-color: #1e1e1e;
+    }
+
+    .popover.popover-top::before {
+      border-top-color: #333;
+    }
+
+    .popover.popover-top::after {
+      border-top-color: #1e1e1e;
+    }
+  }
 `

--- a/web-components/src/styles/utils.ts
+++ b/web-components/src/styles/utils.ts
@@ -12,6 +12,9 @@ export const FLEX = css`
   .flex-col {
     flex-direction: column;
   }
+  .justify-start {
+    justify-content: start;
+  }
   .justify-center {
     justify-content: center;
   }

--- a/web-components/src/styles/utils.ts
+++ b/web-components/src/styles/utils.ts
@@ -13,7 +13,7 @@ export const FLEX = css`
     flex-direction: column;
   }
   .justify-start {
-    justify-content: start;
+    justify-content: flex-start;
   }
   .justify-center {
     justify-content: center;

--- a/web-components/src/types/openfoodfacts.ts
+++ b/web-components/src/types/openfoodfacts.ts
@@ -19,10 +19,18 @@ export type ImageIngredientsProductType = {
   image_ingredients_url: string
   product_name: string
 }
+
+export type ImagesMetaData = {
+  uploaded_t?: number
+  uploader?: string
+  imgid: number
+}
+export type ImagesData = Record<string, ImagesMetaData>
 export type NutrimentsData = Record<string, number | string>
 
 export type NutrimentsProductType = {
   nutriments: NutrimentsData
+  images: ImagesData
   serving_size: string
 }
 

--- a/web-components/src/utils/openfoodfacts.ts
+++ b/web-components/src/utils/openfoodfacts.ts
@@ -4,6 +4,7 @@ export enum ProductFields {
   IMAGE_INGREDIENTS_URL = "image_ingredients_url",
   PRODUCT_NAME = "product_name",
   NUTRIMENTS = "nutriments",
+  IMAGES = "images",
 }
 /**
  * Gets the full image URL by replacing the '400.jpg' suffix with 'full.jpg'.


### PR DESCRIPTION
### What
- Nutrition: The date of the picture is now visible above the picture. Previously the product date was not visible to the user.

### Screenshot

Before:
<img width="1918" height="976" alt="before #382" src="https://github.com/user-attachments/assets/042d5b98-e458-4e9f-8408-6992c0af7348" />

After:
<img width="1918" height="978" alt="after #382" src="https://github.com/user-attachments/assets/e4f926f1-eede-4b4d-887a-bb6f0dbda0d0" />

### Fixes bug(s)
- #382 

### Part of 
- #382 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an info popover to nutrient extraction that shows the nutrition image upload date (or “No information available”).
  * Updated nutrient extraction to use product image data and surface formatted upload timing in the UI.
  * Enhanced zoomable image with configurable toolbar alignment and reset-on-source-change behavior.

* **Bug Fixes**
  * Improved popover behavior by closing when clicking outside.

* **Style**
  * Improved dark-mode styling for popovers.
  * Added a left-aligned layout utility class.

* **Documentation**
  * Added/expanded image-related OpenFoodFacts types and product field support for images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->