### PR TITLE
docs: fix broken link to web-components documentation README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ To have it, you need to follow these steps:
 
 You can find the documentation [here](https://openfoodfacts.github.io/openfoodfacts-webcomponents)
 
-To work on documentation let see [web-components/docs/README.md](./web-components/docs/README.md)
+To work on documentation let see [web-components/README.md](./web-components/README.md)
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ To have it, you need to follow these steps:
 
 You can find the documentation [here](https://openfoodfacts.github.io/openfoodfacts-webcomponents)
 
-To work on documentation let see [web-components/README.md](./web-components/README.md)
+To work on documentation ,you can edit [web-components/README.md](./web-components/README.md)
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ To have it, you need to follow these steps:
 
 You can find the documentation [here](https://openfoodfacts.github.io/openfoodfacts-webcomponents)
 
-To work on documentation let see [this](web-components/docs/README.md)
+To work on documentation let see [web-components/docs/README.md](./web-components/docs/README.md)
 
 ## Rules
 


### PR DESCRIPTION
### What
- Fixed the broken documentation link in `README.md` under the documentation section. Updated the incorrect link to `web-components/docs/README.md` to the correct working path.

### Screenshot
<!-- No visual changes as this is a documentation link fix -->

### Fixes bug(s)
- #385

### Part of
- #385