### PR TITLE
feat(folksonomy): reintroduce property use counts in parentheses

### DIFF
--- a/web-components/src/components/folksonomy/folksonomy-editor-row.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor-row.ts
@@ -48,6 +48,12 @@ export class FolksonomyEditorRow extends LitElement {
   @state() private valueSuggestions: AutocompleteSuggestion[] = []
 
   /**
+   * Map of property keys to their product counts.
+   * @private
+   */
+  @state() private keyCounts: Record<string, number> | null = null
+
+  /**
    * Temporary value used during editing.
    * @private
    */
@@ -110,11 +116,19 @@ export class FolksonomyEditorRow extends LitElement {
     folksonomyApi
       .fetchKeys()
       .then((keys) => {
-        this.keySuggestions = keys.map((key) => ({
-          value: key.k,
-        }))
+        const counts: Record<string, number> = {}
+        this.keySuggestions = keys.map((key) => {
+          counts[key.k] = key.count
+          return {
+            value: key.k,
+            label: `${key.k} (${key.count ?? 0})`,
+          }
+        })
+        this.keyCounts = counts
       })
-      .catch((error) => console.error("Error fetching keys:", error))
+      .catch(() => {
+        this.keyCounts = {}
+      })
   }
 
   /**
@@ -470,8 +484,11 @@ export class FolksonomyEditorRow extends LitElement {
           <a
             class="property-link"
             href="https://wiki.openfoodfacts.org/Folksonomy/Property/${this.key}"
-            >${this.key}</a
           >
+            ${this.key}${this.keyCounts?.[this.key] !== undefined
+              ? ` (${this.keyCounts[this.key]})`
+              : ""}
+          </a>
         </td>
         <td>
           ${this.editable

--- a/web-components/src/components/folksonomy/folksonomy-properties.ts
+++ b/web-components/src/components/folksonomy/folksonomy-properties.ts
@@ -1013,7 +1013,9 @@ export class FolksonomyProperties extends SignalWatcher(LitElement) {
       <tr class="property">
         <td></td>
         <td>
-          <a href="${this.getPropertyUrl(property.k)}" class="property-name"> ${property.k} </a>
+          <a href="${this.getPropertyUrl(property.k)}" class="property-name">
+            ${property.k} (${property.count ?? 0})
+          </a>
         </td>
         <td>
           <a

--- a/web-components/src/components/folksonomy/folksonomy-property-products.ts
+++ b/web-components/src/components/folksonomy/folksonomy-property-products.ts
@@ -1110,7 +1110,10 @@ export class FolksonomyPropertyProducts extends SignalWatcher(LitElement) {
           <div class="main-content">
             <div class="header-section">
               <div class="property-title-container">
-                <h2 id="property_title">${msg("Folksonomy property")}: ${this.propertyName}</h2>
+                <h2 id="property_title">
+                  ${msg("Folksonomy property")}: ${this.propertyName}
+                  (${this.products?.length ?? 0})
+                </h2>
 
                 <div id="fe_infobox" class="info-box">
                   ${msg("Tip: you can also find the")}


### PR DESCRIPTION
## What

Reintroduced product use counts for folksonomy properties to provide users with immediate visibility into property popularity and consensus.

## Key Changes

### FolksonomyProperties
- Added use counts in parentheses next to property names in the main table.

### FolksonomyEditorRow
- Included counts in the autocomplete suggestions for keys.
- Added a reactive `keyCounts` state to display counts for existing properties in the editor table.
- Implemented flicker prevention: counts only appear once metadata is fully loaded.
- Added silent fallback: if the keys API fails, the component gracefully displays only the property names.

### FolksonomyPropertyProducts
- Updated the header to show the total count of products associated with the property.

### Consistency
- Ensured strict `property (123)` spacing.
- Ensured consistent `(0)` rendering for zero counts across all components.

## Fixes bug(s)
Fixes #243 (Reintroducing Property Counts)

## Part of
#243 (Folksonomy UI Improvements)