### PR TITLE
fix(robotoff): handle 502 errors with user-friendly message in nutrient extraction

### DIFF
--- a/web-components/src/api/robotoff.ts
+++ b/web-components/src/api/robotoff.ts
@@ -128,6 +128,9 @@ const robotoff = {
     const url = addParamsToUrl(apiUrl, questionRequestParams)
     // Note: we need credentials to be sure to have all questions
     const response = await fetch(url, { credentials: "include" })
+    if (!response.ok) {
+      throw new Error(`ROBOTOFF_${response.status}`)
+    }
     const result: QuestionsResponse = await response.json()
     return result
   },
@@ -139,16 +142,21 @@ const robotoff = {
    * nutrients insights are supported
    */
   async insights<
-    T extends NutrientsInsight | IngredientSpellcheckInsight | IngredientDetectionInsight,
-  >(requestParams: InsightsRequestParams = {}): Promise<InsightsResponse<T>> {
-    const apiUrl = getApiUrl("/insights")
-    const url = addParamsToUrl(apiUrl, requestParams)
-    // Note: we need credentials to be sure to have all insights
-    const response = await fetch(url, { credentials: "include" })
-    const result: InsightsResponse<T> = await response.json()
-    return result
-  },
+  T extends NutrientsInsight | IngredientSpellcheckInsight | IngredientDetectionInsight,
+>(requestParams: InsightsRequestParams = {}): Promise<InsightsResponse<T>> {
+  const apiUrl = getApiUrl("/insights")
+  const url = addParamsToUrl(apiUrl, requestParams)
 
+  // Note: we need credentials to be sure to have all insights
+  const response = await fetch(url, { credentials: "include" })
+
+  if (!response.ok) {
+    throw new Error(`ROBOTOFF_${response.status}`)
+  }
+
+  const result: InsightsResponse<T> = await response.json()
+  return result
+},
   /**
    * Get insights for the robotoff contribution message
    * Reduces the number of calls to the API by fetching multiple insights at once

--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -282,7 +282,19 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
           </div>
         `
       },
-      error: (error) => html`<p>Error: ${error}</p>`,
+      error: (error) => {
+        const errorMessage = String(error)
+        if (errorMessage.includes("502")) {
+          return html`
+            <p>
+              ${msg(
+                "The Robotoff service is temporarily unavailable. Please try again later."
+              )}
+            </p>
+          `
+        }
+        return html`<p>${msg("An error occurred while loading insights. Please try again.")}</p>`
+      },
     })
   }
 }


### PR DESCRIPTION
### What
- Added error handling for 502 (Bad Gateway) errors in the Robotoff API
- Updated `insights()` and `questionsByProductCode()` in `robotoff.ts` to throw a meaningful error when the API returns a non-OK response
- Updated the `robotoff-nutrient-extraction` component to display a user-friendly message when Robotoff is unavailable (502 error) instead of showing a raw error

### Screenshot
<!-- No visual screenshot needed as this is an error state handler -->

### Fixes bug(s)
- #386

### Part of
- #386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API error handling now validates HTTP responses and surfaces explicit errors when requests fail.
  * Nutrient extraction shows clearer, localized messages — distinguishing temporary service unavailability from other loading errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->