### PR TITLE
feat: add nutripatrol flag form component

### DIFF
--- a/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.stories.ts
+++ b/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/web-components-vite"
 import { html } from "lit"
+import { ref, createRef } from "lit/directives/ref.js"
 import "./nutripatrol-flag-form"
 import type { NutriPatrolFlagForm } from "./nutripatrol-flag-form"
 
@@ -34,19 +35,20 @@ export const Basic: Story = {
     userId: "test_user_story",
     url: "https://world.openfoodfacts.org/product/6410405143648",
   },
-  render: (args) => html`
-    <button
-      @click=${() => document.querySelector("nutripatrol-flag-form")?.setAttribute("open", "")}
-    >
-      Open Flag Form
-    </button>
-    <nutripatrol-flag-form
-      .barcode=${args.barcode}
-      .type=${args.type}
-      .flavor=${args.flavor}
-      ?open=${args.open}
-      user-id=${args.userId as any}
-      .url=${args.url}
-    ></nutripatrol-flag-form>
-  `,
+  render: (args) => {
+    const formRef = createRef<NutriPatrolFlagForm>()
+
+    return html`
+      <button @click=${() => formRef.value?.setAttribute("open", "")}>Open Flag Form</button>
+      <nutripatrol-flag-form
+        ${ref(formRef)}
+        .barcode=${args.barcode}
+        .type=${args.type}
+        .flavor=${args.flavor}
+        ?open=${args.open}
+        user-id=${String(args.userId ?? "")}
+        .url=${args.url}
+      ></nutripatrol-flag-form>
+    `
+  },
 }

--- a/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.stories.ts
+++ b/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.stories.ts
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/web-components"
+import { html } from "lit"
+import "./nutripatrol-flag-form"
+import type { NutriPatrolFlagForm } from "./nutripatrol-flag-form"
+
+const meta: Meta<NutriPatrolFlagForm> = {
+  title: "Components/Nutri Patrol",
+  component: "nutripatrol-flag-form",
+  argTypes: {
+    barcode: { control: "text" },
+    type: {
+      control: { type: "select" },
+      options: ["product", "image", "search"],
+    },
+    flavor: {
+      control: { type: "select" },
+      options: ["off", "obf", "opff", "opf", "off-pro"],
+    },
+    open: { control: "boolean" },
+    userId: { control: "text" },
+    url: { control: "text" },
+  },
+}
+export default meta
+
+type Story = StoryObj<NutriPatrolFlagForm>
+
+export const Basic: Story = {
+  args: {
+    barcode: "6410405143648",
+    type: "product",
+    flavor: "off",
+    open: true,
+    userId: "test_user_story",
+    url: "https://world.openfoodfacts.org/product/6410405143648",
+  },
+  render: (args) => html`
+    <button
+      @click=${() => document.querySelector("nutripatrol-flag-form")?.setAttribute("open", "")}
+    >
+      Open Flag Form
+    </button>
+    <nutripatrol-flag-form
+      .barcode=${args.barcode}
+      .type=${args.type}
+      .flavor=${args.flavor}
+      ?open=${args.open}
+      user-id=${args.userId as any}
+      .url=${args.url}
+    ></nutripatrol-flag-form>
+  `,
+}

--- a/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.stories.ts
+++ b/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.stories.ts
@@ -20,13 +20,14 @@ const meta: Meta<NutriPatrolFlagForm> = {
     open: { control: "boolean" },
     userId: { control: "text" },
     url: { control: "text" },
+    imageId: { control: "text" },
   },
 }
 export default meta
 
 type Story = StoryObj<NutriPatrolFlagForm>
 
-export const Basic: Story = {
+export const FlagProduct: Story = {
   args: {
     barcode: "6410405143648",
     type: "product",
@@ -48,7 +49,28 @@ export const Basic: Story = {
         ?open=${args.open}
         user-id=${String(args.userId ?? "")}
         .url=${args.url}
+        .imageId=${args.imageId ?? ""}
       ></nutripatrol-flag-form>
     `
   },
+}
+
+export const FlagImage: Story = {
+  args: {
+    ...FlagProduct.args,
+    barcode: "3017620422003",
+    type: "image",
+    imageId: "front_fr",
+    url: "https://image.openfoodfacts.org/images/products/301/762/042/2003/149.400.jpg",
+  },
+  render: FlagProduct.render,
+}
+
+export const FlagSearch: Story = {
+  args: {
+    ...FlagProduct.args,
+    type: "search",
+    url: "https://world.openfoodfacts.org/cgi/search.pl?search_terms=nutella",
+  },
+  render: FlagProduct.render,
 }

--- a/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.stories.ts
+++ b/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.stories.ts
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/web-components"
+import type { Meta, StoryObj } from "@storybook/web-components-vite"
 import { html } from "lit"
 import "./nutripatrol-flag-form"
 import type { NutriPatrolFlagForm } from "./nutripatrol-flag-form"

--- a/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
+++ b/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
@@ -331,18 +331,18 @@ export class NutriPatrolFlagForm extends LitElement {
                       @change=${(e: Event) => (this.reason = (e.target as HTMLSelectElement).value)}
                       required
                     >
-                      <option value="Wrong Barcode" ?selected=${this.reason === "Wrong Barcode"}>
-                        ${msg("Wrong Barcode")}
-                      </option>
-                      <option value="Missing Data" ?selected=${this.reason === "Missing Data"}>
-                        ${msg("Missing Data")}
-                      </option>
-                      <option value="Wrong Data" ?selected=${this.reason === "Wrong Data"}>
-                        ${msg("Wrong Data")}
-                      </option>
-                      <option value="Other" ?selected=${this.reason === "Other"}>
-                        ${msg("Other")}
-                      </option>
+                      ${[
+                        { value: "Wrong Barcode", label: msg("Wrong Barcode") },
+                        { value: "Missing Data", label: msg("Missing Data") },
+                        { value: "Wrong Data", label: msg("Wrong Data") },
+                        { value: "Other", label: msg("Other") },
+                      ].map(
+                        (opt) => html`
+                          <option value="${opt.value}" ?selected=${this.reason === opt.value}>
+                            ${opt.label}
+                          </option>
+                        `
+                      )}
                     </select>
                   </div>
 

--- a/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
+++ b/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
@@ -1,0 +1,353 @@
+import { LitElement, html, css, nothing } from "lit"
+import { customElement, property, state, query } from "lit/decorators.js"
+import { localized, msg } from "@lit/localize"
+import { NutriPatrol } from "@openfoodfacts/openfoodfacts-nodejs"
+import { BASE } from "../../styles/base"
+
+/**
+ * Interface mimicking the NutriPatrol API's FlagCreate schema.
+ * We define it locally because the current SDK alpha version installed
+ * does not export the type directly.
+ */
+interface FlagCreatePayload {
+  type: "product" | "image" | "search"
+  url: string
+  user_id: string
+  source: "web" | "mobile" | "robotoff"
+  flavor: "off" | "obf" | "opff" | "opf" | "off-pro"
+  barcode?: string
+  image_id?: string
+  reason?: string
+  comment?: string
+}
+
+/**
+ * Nutri-Patrol Flag Form component
+ * Allows reporting a product or image issue directly from the page.
+ * @element nutripatrol-flag-form
+ */
+@customElement("nutripatrol-flag-form")
+@localized()
+export class NutriPatrolFlagForm extends LitElement {
+  static override styles = [
+    BASE,
+    css`
+      :host {
+        display: block;
+        font-family: "Plus Jakarta Sans Variable", system-ui, sans-serif;
+      }
+
+      dialog {
+        padding: 0;
+        border: none;
+        border-radius: 8px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        background: #fdfaf5; /* Matches the NutriPatrol off-white background */
+        color: #333;
+        max-width: 500px;
+        width: 100%;
+      }
+
+      dialog::backdrop {
+        background: rgba(0, 0, 0, 0.4);
+      }
+
+      .modal-header {
+        padding: 1rem;
+        border-bottom: 1px solid #e0e0e0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .modal-title {
+        font-size: 1.5rem;
+        margin: 0;
+        text-align: center;
+        width: 100%;
+        font-weight: 500;
+        color: #000;
+      }
+
+      .close-btn {
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        cursor: pointer;
+        color: #666;
+        padding: 0 0.5rem;
+        position: absolute;
+        right: 1rem;
+      }
+
+      .modal-body {
+        padding: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .form-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      label {
+        font-size: 0.85rem;
+        color: #555;
+      }
+
+      input,
+      select,
+      textarea {
+        font-family: inherit;
+        padding: 0.5rem;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        font-size: 1rem;
+        width: 100%;
+        box-sizing: border-box;
+        background: #fafafa;
+      }
+
+      input:disabled {
+        background: #f0f0f0;
+        color: #888;
+      }
+
+      textarea {
+        resize: vertical;
+        min-height: 80px;
+      }
+
+      .submit-btn {
+        background-color: #32863b; /* Green button from provided UI */
+        color: white;
+        border: none;
+        padding: 0.75rem 1rem;
+        border-radius: 4px;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        margin-top: 1rem;
+        width: 100%;
+        transition: background-color 0.2s;
+      }
+
+      .submit-btn:hover {
+        background-color: #2b7433;
+      }
+
+      .submit-btn:disabled {
+        background-color: #92bfa4;
+        cursor: not-allowed;
+      }
+
+      .message {
+        padding: 1rem;
+        text-align: center;
+        border-radius: 4px;
+        margin-top: 1rem;
+      }
+
+      .message.error {
+        background-color: #ffebee;
+        color: #c62828;
+        border: 1px solid #ef9a9a;
+      }
+
+      .message.success {
+        background-color: #e8f5e9;
+        color: #2e7d32;
+        border: 1px solid #a5d6a7;
+      }
+    `,
+  ]
+
+  @property({ type: String })
+  barcode = ""
+
+  @property({ type: String })
+  type: "product" | "image" | "search" = "product"
+
+  @property({ type: String, attribute: "image-id" })
+  imageId = ""
+
+  @property({ type: String })
+  flavor: "off" | "obf" | "opff" | "opf" | "off-pro" = "off"
+
+  @property({ type: String, attribute: "user-id" })
+  userId = ""
+
+  @property({ type: String })
+  url = ""
+
+  @property({ type: Boolean, reflect: true })
+  open = false
+
+  @state()
+  private loading = false
+
+  @state()
+  private error: string | null = null
+
+  @state()
+  private success = false
+
+  @state()
+  private reason = "Wrong Data"
+
+  @state()
+  private comment = ""
+
+  @query("dialog")
+  private dialog!: HTMLDialogElement
+
+  private client = new NutriPatrol(globalThis.fetch)
+
+  override updated(changedProperties: Map<string, any>) {
+    if (changedProperties.has("open")) {
+      if (this.open) {
+        this.dialog?.showModal()
+        this.resetForm()
+      } else {
+        this.dialog?.close()
+      }
+    }
+  }
+
+  private resetForm() {
+    this.success = false
+    this.error = null
+    this.loading = false
+    this.reason = "Wrong Data"
+    this.comment = ""
+  }
+
+  private handleClose() {
+    this.open = false
+    this.dispatchEvent(new CustomEvent("close", { bubbles: true, composed: true }))
+  }
+
+  private async handleSubmit(e: Event) {
+    e.preventDefault()
+
+    if (!this.userId) {
+      this.error = msg("User ID is required to submit a flag. Please log in.")
+      return
+    }
+
+    this.loading = true
+    this.error = null
+
+    // As per the SDK types, url, user_id, source, flavor, and type are required
+    const payload: FlagCreatePayload = {
+      type: this.type,
+      url: this.url || window.location.href,
+      user_id: this.userId,
+      source: "web",
+      flavor: this.flavor as FlagCreatePayload["flavor"],
+      reason: this.reason,
+      comment: this.comment || undefined,
+    }
+
+    if (this.barcode) {
+      payload.barcode = this.barcode
+    }
+
+    if (this.type === "image" && this.imageId) {
+      payload.image_id = this.imageId
+    }
+
+    try {
+      // Temporary bypass until the SDK version is bumped and types align
+      const { error } = await this.client.createFlag(payload)
+      if (error) {
+        console.error("Failed to create flag:", error)
+        this.error = msg("Failed to submit flag. Please try again later.")
+      } else {
+        this.success = true
+        // Close modal automatically after delay
+        setTimeout(() => this.handleClose(), 3000)
+      }
+    } catch (err: any) {
+      console.error("Flag API submission error:", err)
+      this.error = err.message || msg("An unexpected error occurred.")
+    } finally {
+      this.loading = false
+    }
+  }
+
+  override render() {
+    return html`
+      <dialog @close=${this.handleClose}>
+        <div class="modal-header">
+          <h2 class="modal-title">${msg("Flag a product")}</h2>
+          <!-- Close button -->
+          <button class="close-btn" @click=${this.handleClose} aria-label="${msg("Close")}">
+            &times;
+          </button>
+        </div>
+
+        <div class="modal-body">
+          ${this.success
+            ? html`
+                <div class="message success">
+                  ${msg("Thank you for reporting. Your flag has been submitted successfully.")}
+                </div>
+              `
+            : html`
+                <form @submit=${this.handleSubmit}>
+                  ${this.barcode
+                    ? html`
+                        <div class="form-group">
+                          <label for="barcode">${msg("Barcode")} *</label>
+                          <input type="text" id="barcode" .value=${this.barcode} disabled />
+                        </div>
+                      `
+                    : nothing}
+
+                  <div class="form-group">
+                    <label for="reason">${msg("Reason")} *</label>
+                    <select
+                      id="reason"
+                      .value=${this.reason}
+                      @change=${(e: any) => (this.reason = e.target.value)}
+                      required
+                    >
+                      <option value="Wrong Barcode">${msg("Wrong Barcode")}</option>
+                      <option value="Missing Data">${msg("Missing Data")}</option>
+                      <option value="Wrong Data">${msg("Wrong Data")}</option>
+                      <option value="Other">${msg("Other")}</option>
+                    </select>
+                  </div>
+
+                  <div class="form-group">
+                    <label for="comment">${msg("Comment")}</label>
+                    <textarea
+                      id="comment"
+                      .value=${this.comment}
+                      @input=${(e: any) => (this.comment = e.target.value)}
+                      placeholder=${msg("Optional details")}
+                    ></textarea>
+                  </div>
+
+                  ${this.error ? html`<div class="message error">${this.error}</div>` : nothing}
+
+                  <button type="submit" class="submit-btn" ?disabled=${this.loading}>
+                    ${this.loading ? msg("Submitting...") : msg("FLAG PRODUCT")}
+                  </button>
+                </form>
+              `}
+        </div>
+      </dialog>
+    `
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "nutripatrol-flag-form": NutriPatrolFlagForm
+  }
+}

--- a/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
+++ b/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
@@ -227,6 +227,8 @@ export class NutriPatrolFlagForm extends LitElement {
   }
 
   private handleClose() {
+    if (!this.open) return
+
     if (this.autoCloseTimer) {
       clearTimeout(this.autoCloseTimer)
       this.autoCloseTimer = undefined

--- a/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
+++ b/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
@@ -205,6 +205,7 @@ export class NutriPatrolFlagForm extends LitElement {
   private dialog!: HTMLDialogElement
 
   private client = new NutriPatrol(globalThis.fetch)
+  private autoCloseTimer?: ReturnType<typeof setTimeout>
 
   override updated(changedProperties: Map<string, any>) {
     if (changedProperties.has("open")) {
@@ -226,8 +227,20 @@ export class NutriPatrolFlagForm extends LitElement {
   }
 
   private handleClose() {
+    if (this.autoCloseTimer) {
+      clearTimeout(this.autoCloseTimer)
+      this.autoCloseTimer = undefined
+    }
     this.open = false
     this.dispatchEvent(new CustomEvent("close", { bubbles: true, composed: true }))
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback()
+    if (this.autoCloseTimer) {
+      clearTimeout(this.autoCloseTimer)
+      this.autoCloseTimer = undefined
+    }
   }
 
   private async handleSubmit(e: Event) {
@@ -269,11 +282,11 @@ export class NutriPatrolFlagForm extends LitElement {
       } else {
         this.success = true
         // Close modal automatically after delay
-        setTimeout(() => this.handleClose(), 3000)
+        this.autoCloseTimer = setTimeout(() => this.handleClose(), 3000)
       }
     } catch (err: any) {
       console.error("Flag API submission error:", err)
-      this.error = err.message || msg("An unexpected error occurred.")
+      this.error = msg("An unexpected error occurred.")
     } finally {
       this.loading = false
     }
@@ -313,13 +326,21 @@ export class NutriPatrolFlagForm extends LitElement {
                     <select
                       id="reason"
                       .value=${this.reason}
-                      @change=${(e: any) => (this.reason = e.target.value)}
+                      @change=${(e: Event) => (this.reason = (e.target as HTMLSelectElement).value)}
                       required
                     >
-                      <option value="Wrong Barcode">${msg("Wrong Barcode")}</option>
-                      <option value="Missing Data">${msg("Missing Data")}</option>
-                      <option value="Wrong Data">${msg("Wrong Data")}</option>
-                      <option value="Other">${msg("Other")}</option>
+                      <option value="Wrong Barcode" ?selected=${this.reason === "Wrong Barcode"}>
+                        ${msg("Wrong Barcode")}
+                      </option>
+                      <option value="Missing Data" ?selected=${this.reason === "Missing Data"}>
+                        ${msg("Missing Data")}
+                      </option>
+                      <option value="Wrong Data" ?selected=${this.reason === "Wrong Data"}>
+                        ${msg("Wrong Data")}
+                      </option>
+                      <option value="Other" ?selected=${this.reason === "Other"}>
+                        ${msg("Other")}
+                      </option>
                     </select>
                   </div>
 
@@ -328,7 +349,8 @@ export class NutriPatrolFlagForm extends LitElement {
                     <textarea
                       id="comment"
                       .value=${this.comment}
-                      @input=${(e: any) => (this.comment = e.target.value)}
+                      @input=${(e: Event) =>
+                        (this.comment = (e.target as HTMLTextAreaElement).value)}
                       placeholder=${msg("Optional details")}
                     ></textarea>
                   </div>

--- a/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
+++ b/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
@@ -257,7 +257,7 @@ export class NutriPatrolFlagForm extends LitElement {
     }
   }
 
-  override updated(changedProperties: Map<string, any>) {
+  override updated(changedProperties: Map<string, unknown>) {
     if (changedProperties.has("open")) {
       if (this.open) {
         if (this.dialog && !this.dialog.open) {
@@ -358,7 +358,7 @@ export class NutriPatrolFlagForm extends LitElement {
         // Close modal automatically after delay
         this.autoCloseTimer = setTimeout(() => this.handleClose(), 3000)
       }
-    } catch (err: any) {
+    } catch (err) {
       console.error("Flag API submission error:", err)
       this.error = msg("An unexpected error occurred.")
     } finally {

--- a/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
+++ b/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
@@ -196,7 +196,7 @@ export class NutriPatrolFlagForm extends LitElement {
   private success = false
 
   @state()
-  private reason = "Wrong Data"
+  private reason = "wrong_data"
 
   @state()
   private comment = ""
@@ -207,6 +207,50 @@ export class NutriPatrolFlagForm extends LitElement {
   private client = new NutriPatrol(globalThis.fetch)
   private autoCloseTimer?: ReturnType<typeof setTimeout>
 
+  private get modalTitle(): string {
+    switch (this.type) {
+      case "image":
+        return msg("Flag an image")
+      case "search":
+        return msg("Flag a search result")
+      default:
+        return msg("Flag a product")
+    }
+  }
+
+  private get reasonOptions(): { value: string; label: string }[] {
+    switch (this.type) {
+      case "image":
+        return [
+          { value: "inappropriate", label: msg("Inappropriate") },
+          { value: "outdated", label: msg("Outdated") },
+          { value: "includes_personal_infos", label: msg("Includes Personal Information") },
+          { value: "duplicate", label: msg("Duplicate") },
+          { value: "other", label: msg("Other") },
+        ]
+      case "search":
+        return [{ value: "other", label: msg("Other") }]
+      default:
+        return [
+          { value: "wrong_barcode", label: msg("Wrong Barcode") },
+          { value: "missing_data", label: msg("Missing Data") },
+          { value: "wrong_data", label: msg("Wrong Data") },
+          { value: "other", label: msg("Other") },
+        ]
+    }
+  }
+
+  private get submitLabel(): string {
+    switch (this.type) {
+      case "image":
+        return msg("FLAG IMAGE")
+      case "search":
+        return msg("FLAG SEARCH")
+      default:
+        return msg("FLAG PRODUCT")
+    }
+  }
+
   override updated(changedProperties: Map<string, any>) {
     if (changedProperties.has("open")) {
       if (this.open) {
@@ -216,13 +260,18 @@ export class NutriPatrolFlagForm extends LitElement {
         this.dialog?.close()
       }
     }
+
+    if (changedProperties.has("type")) {
+      this.reason = this.reasonOptions[0].value
+    }
   }
 
   private resetForm() {
     this.success = false
     this.error = null
     this.loading = false
-    this.reason = "Wrong Data"
+    // Reset reason to the first valid option for the current type
+    this.reason = this.reasonOptions[0].value
     this.comment = ""
   }
 
@@ -253,6 +302,11 @@ export class NutriPatrolFlagForm extends LitElement {
       return
     }
 
+    if (this.type === "image" && !this.imageId) {
+      this.error = msg("Image ID is required to flag an image.")
+      return
+    }
+
     this.loading = true
     this.error = null
 
@@ -267,11 +321,11 @@ export class NutriPatrolFlagForm extends LitElement {
       comment: this.comment || undefined,
     }
 
-    if (this.barcode) {
+    if (this.barcode && this.type !== "search") {
       payload.barcode = this.barcode
     }
 
-    if (this.type === "image" && this.imageId) {
+    if (this.type === "image") {
       payload.image_id = this.imageId
     }
 
@@ -298,7 +352,7 @@ export class NutriPatrolFlagForm extends LitElement {
     return html`
       <dialog @close=${this.handleClose}>
         <div class="modal-header">
-          <h2 class="modal-title">${msg("Flag a product")}</h2>
+          <h2 class="modal-title">${this.modalTitle}</h2>
           <!-- Close button -->
           <button class="close-btn" @click=${this.handleClose} aria-label="${msg("Close")}">
             &times;
@@ -314,11 +368,30 @@ export class NutriPatrolFlagForm extends LitElement {
               `
             : html`
                 <form @submit=${this.handleSubmit}>
-                  ${this.barcode
+                  ${this.type === "image" && this.url
+                    ? html`
+                        <div class="form-group image-preview">
+                          <img
+                            src=${this.url}
+                            alt=${msg("Image to flag")}
+                            style="max-width: 100%; max-height: 200px; object-fit: contain; border: 1px solid #e0e0e0; border-radius: 4px;"
+                          />
+                        </div>
+                      `
+                    : nothing}
+                  ${this.barcode && this.type !== "search"
                     ? html`
                         <div class="form-group">
                           <label for="barcode">${msg("Barcode")} *</label>
                           <input type="text" id="barcode" .value=${this.barcode} disabled />
+                        </div>
+                      `
+                    : nothing}
+                  ${this.type === "image" && this.imageId
+                    ? html`
+                        <div class="form-group">
+                          <label for="image-id">${msg("Image ID")} *</label>
+                          <input type="text" id="image-id" .value=${this.imageId} disabled />
                         </div>
                       `
                     : nothing}
@@ -331,12 +404,7 @@ export class NutriPatrolFlagForm extends LitElement {
                       @change=${(e: Event) => (this.reason = (e.target as HTMLSelectElement).value)}
                       required
                     >
-                      ${[
-                        { value: "Wrong Barcode", label: msg("Wrong Barcode") },
-                        { value: "Missing Data", label: msg("Missing Data") },
-                        { value: "Wrong Data", label: msg("Wrong Data") },
-                        { value: "Other", label: msg("Other") },
-                      ].map(
+                      ${this.reasonOptions.map(
                         (opt) => html`
                           <option value="${opt.value}" ?selected=${this.reason === opt.value}>
                             ${opt.label}
@@ -360,7 +428,7 @@ export class NutriPatrolFlagForm extends LitElement {
                   ${this.error ? html`<div class="message error">${this.error}</div>` : nothing}
 
                   <button type="submit" class="submit-btn" ?disabled=${this.loading}>
-                    ${this.loading ? msg("Submitting...") : msg("FLAG PRODUCT")}
+                    ${this.loading ? msg("Submitting...") : this.submitLabel}
                   </button>
                 </form>
               `}

--- a/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
+++ b/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
@@ -4,17 +4,23 @@ import { localized, msg } from "@lit/localize"
 import { NutriPatrol } from "@openfoodfacts/openfoodfacts-nodejs"
 import { BASE } from "../../styles/base"
 
+const VALID_TYPES = ["product", "image", "search"] as const
+const VALID_FLAVORS = ["off", "obf", "opff", "opf", "off-pro"] as const
+
+type FlagType = (typeof VALID_TYPES)[number]
+type FlagFlavor = (typeof VALID_FLAVORS)[number]
+
 /**
  * Interface mimicking the NutriPatrol API's FlagCreate schema.
  * We define it locally because the current SDK alpha version installed
  * does not export the type directly.
  */
 interface FlagCreatePayload {
-  type: "product" | "image" | "search"
+  type: FlagType
   url: string
   user_id: string
   source: "web" | "mobile" | "robotoff"
-  flavor: "off" | "obf" | "opff" | "opf" | "off-pro"
+  flavor: FlagFlavor
   barcode?: string
   image_id?: string
   reason?: string
@@ -42,7 +48,7 @@ export class NutriPatrolFlagForm extends LitElement {
         border: none;
         border-radius: 8px;
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-        background: #fdfaf5; /* Matches the NutriPatrol off-white background */
+        background: #fdfaf5;
         color: #333;
         max-width: 500px;
         width: 100%;
@@ -122,7 +128,7 @@ export class NutriPatrolFlagForm extends LitElement {
       }
 
       .submit-btn {
-        background-color: #32863b; /* Green button from provided UI */
+        background-color: #32863b;
         color: white;
         border: none;
         padding: 0.75rem 1rem;
@@ -169,13 +175,13 @@ export class NutriPatrolFlagForm extends LitElement {
   barcode = ""
 
   @property({ type: String })
-  type: "product" | "image" | "search" = "product"
+  type: FlagType = "product"
 
   @property({ type: String, attribute: "image-id" })
   imageId = ""
 
   @property({ type: String })
-  flavor: "off" | "obf" | "opff" | "opf" | "off-pro" = "off"
+  flavor: FlagFlavor = "off"
 
   @property({ type: String, attribute: "user-id" })
   userId = ""
@@ -299,15 +305,12 @@ export class NutriPatrolFlagForm extends LitElement {
   private async handleSubmit(e: Event) {
     e.preventDefault()
 
-    const validTypes: FlagCreatePayload["type"][] = ["product", "image", "search"]
-    const validFlavors: FlagCreatePayload["flavor"][] = ["off", "obf", "opff", "opf", "off-pro"]
-
-    if (!validTypes.includes(this.type as FlagCreatePayload["type"])) {
+    if (!VALID_TYPES.includes(this.type as FlagType)) {
       this.error = msg("Invalid flag type.")
       return
     }
 
-    if (!validFlavors.includes(this.flavor as FlagCreatePayload["flavor"])) {
+    if (!VALID_FLAVORS.includes(this.flavor as FlagFlavor)) {
       this.error = msg("Invalid flavor.")
       return
     }

--- a/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
+++ b/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
@@ -254,7 +254,9 @@ export class NutriPatrolFlagForm extends LitElement {
   override updated(changedProperties: Map<string, any>) {
     if (changedProperties.has("open")) {
       if (this.open) {
-        this.dialog?.showModal()
+        if (this.dialog && !this.dialog.open) {
+          this.dialog.showModal()
+        }
         this.resetForm()
       } else {
         this.dialog?.close()
@@ -296,6 +298,19 @@ export class NutriPatrolFlagForm extends LitElement {
 
   private async handleSubmit(e: Event) {
     e.preventDefault()
+
+    const validTypes: FlagCreatePayload["type"][] = ["product", "image", "search"]
+    const validFlavors: FlagCreatePayload["flavor"][] = ["off", "obf", "opff", "opf", "off-pro"]
+
+    if (!validTypes.includes(this.type as FlagCreatePayload["type"])) {
+      this.error = msg("Invalid flag type.")
+      return
+    }
+
+    if (!validFlavors.includes(this.flavor as FlagCreatePayload["flavor"])) {
+      this.error = msg("Invalid flavor.")
+      return
+    }
 
     if (!this.userId) {
       this.error = msg("User ID is required to submit a flag. Please log in.")

--- a/web-components/src/off-webcomponents.ts
+++ b/web-components/src/off-webcomponents.ts
@@ -17,6 +17,7 @@ export { AutocompleteInput } from "./components/shared/autocomplete-input"
 export { RobotoffIngredientDetection as RobotoffCrops } from "./components/robotoff-ingredient-detection/robotoff-ingredient-detection"
 export { ProductCard } from "./components/product-card/product-card"
 export { NewsFeed } from "./components/news-feed/news-feed"
+export { NutriPatrolFlagForm } from "./components/nutripatrol-flag-form/nutripatrol-flag-form"
 
 // Will be added in the future when design is ready
 // export { KnowledgePanelsComponent } from "./components/knowledge-panels/knowledge-panels"


### PR DESCRIPTION


### What
Created the new Nutri patrol flag form component

### Screenshot
<img width="645" height="772" alt="Screenshot 2026-04-14 110138" src="https://github.com/user-attachments/assets/02a639b3-c934-4360-8389-170efc5f6ce5" />
<img width="691" height="561" alt="Screenshot 2026-04-14 110125" src="https://github.com/user-attachments/assets/f2989f6c-2270-4c4c-9764-6336fbdde9e2" />

<img width="633" height="474" alt="Screenshot 2026-04-14 110149" src="https://github.com/user-attachments/assets/6758db55-12f1-46de-b06e-cfd18970a48b" />




### Part of 
(https://github.com/openfoodfacts/openfoodfacts-explorer/issues/639)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a flag submission modal for product/image/search reports with configurable reason, flavor, URL, barcode/image handling, validation, error display, success confirmation and auto-close.

* **Developer Preview**
  * Added Storybook stories to preview and interact with the flag form (controls for type, barcode, flavor, open, user ID, URL).

* **Chores**
  * Exported the new flag form component for use across the web-components package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->