### PR TITLE
fix(robotoff-question): show user-friendly error message when questions fail to load

### DIFF
--- a/web-components/src/components/robotoff-question/robotoff-question.ts
+++ b/web-components/src/components/robotoff-question/robotoff-question.ts
@@ -43,6 +43,11 @@ export class RobotoffQuestion extends SignalWatcher(LitElement) {
         font-style: italic;
         color: var(--robotoff-question-message-color, #444);
       }
+      .error-message {
+        color: var(--robotoff-question-error-color, #c0392b);
+        margin-top: 1rem;
+        font-weight: 500;
+      }
       @media (prefers-color-scheme: dark) {
         :host {
           background: var(--robotoff-question-bg-dark, #181a1b);
@@ -141,7 +146,10 @@ export class RobotoffQuestion extends SignalWatcher(LitElement) {
   override render() {
     return this._questionsTask.render({
       pending: () => (this.showLoading ? html`<off-wc-loader></off-wc-loader>` : nothing),
-      error: (error) => (this.showError ? html`<div>Error: ${error}</div>` : nothing),
+      error: () =>
+        this.showError
+          ? html`<div class="error-message">${msg("Unable to load questions. Please try again later.")}</div>`
+          : nothing,
       complete: (questionsList) => {
         const index = currentQuestionIndex(this.productCode).get() ?? 0
         const question = questionsList[index]


### PR DESCRIPTION
Improve error handling in the robotoff-question component.

Previously the component rendered the raw error object when question loading failed.
This change replaces it with a localized user-friendly error message and adds styling
for the error message to ensure consistent UI.

This improves user experience and avoids exposing technical error details.