### PR TITLE
feat(folksonomy): added dark mode support via CSS custom properties  

### DIFF
--- a/web-components/src/components/folksonomy/delete-modal.ts
+++ b/web-components/src/components/folksonomy/delete-modal.ts
@@ -3,6 +3,7 @@ import { LitElement, html, css } from "lit-element"
 import { customElement, state } from "lit/decorators.js"
 import { getButtonClasses, ButtonType } from "../../styles/buttons"
 import { MODAL } from "../../styles/modal"
+import { FOLKSONOMY_THEME } from "../../styles/folksonomy-theme"
 
 /**
  * @customElement("delete-modal")
@@ -15,6 +16,7 @@ export class DeleteModal extends LitElement {
   @state() open = true
 
   static override styles = [
+    FOLKSONOMY_THEME,
     MODAL,
     ...getButtonClasses([ButtonType.Danger, ButtonType.Chocolate]),
     css`
@@ -34,7 +36,7 @@ export class DeleteModal extends LitElement {
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
-        background: white;
+        background: var(--off-folksonomy-modal-bg, white);
         border-radius: 12px;
         padding: 24px;
         min-width: 400px;
@@ -69,7 +71,7 @@ export class DeleteModal extends LitElement {
       .modal-title {
         font-size: 20px;
         font-weight: 600;
-        color: #1f2937;
+        color: var(--off-folksonomy-modal-title, #1f2937);
         margin: 0 0 24px 0;
         text-align: center;
         margin-bottom: 12px;
@@ -81,7 +83,7 @@ export class DeleteModal extends LitElement {
 
       .modal-message {
         font-size: 16px;
-        color: #6b7280;
+        color: var(--off-folksonomy-modal-message, #6b7280);
         line-height: 1.5;
         margin: 0;
       }
@@ -109,14 +111,14 @@ export class DeleteModal extends LitElement {
       }
 
       .chocolate-button {
-        background: #341100;
-        border: 1px solid #341100;
+        background: var(--off-folksonomy-accent, #341100);
+        border: 1px solid var(--off-folksonomy-accent, #341100);
         color: white;
       }
 
       .danger-button {
-        border: 1px solid #ff5252;
-        background: #ff5252;
+        border: 1px solid var(--off-folksonomy-danger, #ff5252);
+        background: var(--off-folksonomy-danger, #ff5252);
         color: white;
       }
 

--- a/web-components/src/components/folksonomy/folksonomy-editor-row.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor-row.ts
@@ -4,6 +4,7 @@ import "./delete-modal"
 import "./new-key-modal"
 import "../shared/autocomplete-input"
 import folksonomyApi from "../../api/folksonomy"
+import { FOLKSONOMY_THEME } from "../../styles/folksonomy-theme"
 import { msg } from "@lit/localize"
 import { getButtonClasses, ButtonType } from "../../styles/buttons"
 import { FOLKSONOMY_INPUT } from "../../styles/folksonomy-input"
@@ -317,23 +318,24 @@ export class FolksonomyEditorRow extends LitElement {
   }
 
   static override styles = [
+    FOLKSONOMY_THEME,
     FOLKSONOMY_INPUT,
     ...getButtonClasses([ButtonType.Chocolate]),
     css`
       :host {
         font-family: Arial, sans-serif;
         font-size: 0.9rem;
-        color: #333;
+        color: var(--off-folksonomy-text, #333);
         width: 100%;
         display: contents;
       }
 
       .odd-row {
-        background-color: #ffffff;
+        background-color: var(--off-folksonomy-bg, #ffffff);
       }
 
       .even-row {
-        background-color: #f2f2f2;
+        background-color: var(--off-folksonomy-row-even-bg-alt, #f2f2f2);
       }
 
       .button-container {
@@ -359,7 +361,7 @@ export class FolksonomyEditorRow extends LitElement {
       }
 
       .property-link {
-        color: black;
+        color: var(--off-folksonomy-text, black);
       }
 
       #create-button {

--- a/web-components/src/components/folksonomy/folksonomy-editor.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor.ts
@@ -3,6 +3,7 @@ import { customElement, property, state } from "lit/decorators.js"
 import { localized, msg } from "@lit/localize"
 import "./folksonomy-editor-row"
 import folksonomyApi from "../../api/folksonomy"
+import { FOLKSONOMY_THEME } from "../../styles/folksonomy-theme"
 
 /**
  * Folksonomy Editor
@@ -47,97 +48,100 @@ export class FolksonomyEditor extends LitElement {
   @property({ type: String, attribute: "folksonomy-engine-url" })
   folksonomyEngineUrl = "https://wiki.openfoodfacts.org/Folksonomy_Engine"
 
-  static override styles = css`
-    :host {
-      font-family: Arial, sans-serif;
-      color: #333;
-    }
-    .feus {
-      margin-bottom: 1rem;
-      background-color: #fff;
-      border: 1px solid #ddd;
-      border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      padding: 1rem;
-    }
-    .feus h2 {
-      font-size: 2.2rem;
-      font-weight: 600;
-      color: #222;
-      margin-top: 10px;
-      margin-bottom: 0.5rem;
-    }
-    .feus p {
-      font-size: 0.9rem;
-      line-height: 1.5;
-      margin-bottom: 0.8rem;
-    }
-    #free_properties_form table {
-      width: 100%;
-      border-collapse: collapse;
-      margin-top: 1rem;
-      border: solid 1px #ddd;
-      font-size: 0.9rem;
-      table-layout: fixed;
-    }
-    #free_properties_form table th,
-    #free_properties_form table td {
-      padding: 0.8rem;
-      text-align: left;
-      border: solid 1px #ddd;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-    #free_properties_form table th {
-      background-color: #dedede;
-      font-weight: bold;
-      cursor: pointer;
-      user-select: none;
-      white-space: nowrap;
-    }
-    .sort-header {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.2em;
-    }
-    .sort-icon {
-      display: inline-flex;
-      flex-direction: column;
-      margin-left: 0.5em;
-      font-size: 0.9em;
-      line-height: 1;
-    }
-    .sort-arrow {
-      opacity: 0.3;
-      height: 0.8em;
-      width: 0.8em;
-      padding: 0;
-      margin: 0;
-      display: block;
-    }
-    .sort-arrow.active {
-      opacity: 1;
-    }
-    #free_properties_form table th.sortable {
-      padding-right: 0.8em;
-    }
-    #free_properties_form table th.sortable::before,
-    #free_properties_form table th.sortable::after {
-      display: none;
-    }
-    #free_properties_form table tr {
-      height: 4rem;
-    }
-    #free_properties_form table tr:nth-child(even) {
-      background-color: #f9f9f9;
-    }
-    @media (max-width: 480px) {
-      #free_properties_form table tr:first-child {
-        height: 0.5rem;
+  static override styles = [
+    FOLKSONOMY_THEME,
+    css`
+      :host {
+        font-family: Arial, sans-serif;
+        color: var(--off-folksonomy-text, #333);
       }
-    }
-  `
+      .feus {
+        margin-bottom: 1rem;
+        background-color: var(--off-folksonomy-bg, #fff);
+        border: 1px solid var(--off-folksonomy-border, #ddd);
+        border-radius: 8px;
+        box-shadow: 0 2px 4px var(--off-folksonomy-shadow, rgba(0, 0, 0, 0.1));
+        padding: 1rem;
+      }
+      .feus h2 {
+        font-size: 2.2rem;
+        font-weight: 600;
+        color: var(--off-folksonomy-text-secondary, #222);
+        margin-top: 10px;
+        margin-bottom: 0.5rem;
+      }
+      .feus p {
+        font-size: 0.9rem;
+        line-height: 1.5;
+        margin-bottom: 0.8rem;
+      }
+      #free_properties_form table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+        border: solid 1px var(--off-folksonomy-border, #ddd);
+        font-size: 0.9rem;
+        table-layout: fixed;
+      }
+      #free_properties_form table th,
+      #free_properties_form table td {
+        padding: 0.8rem;
+        text-align: left;
+        border: solid 1px var(--off-folksonomy-border, #ddd);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      #free_properties_form table th {
+        background-color: var(--off-folksonomy-table-header-bg, #dedede);
+        font-weight: bold;
+        cursor: pointer;
+        user-select: none;
+        white-space: nowrap;
+      }
+      .sort-header {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.2em;
+      }
+      .sort-icon {
+        display: inline-flex;
+        flex-direction: column;
+        margin-left: 0.5em;
+        font-size: 0.9em;
+        line-height: 1;
+      }
+      .sort-arrow {
+        opacity: 0.3;
+        height: 0.8em;
+        width: 0.8em;
+        padding: 0;
+        margin: 0;
+        display: block;
+      }
+      .sort-arrow.active {
+        opacity: 1;
+      }
+      #free_properties_form table th.sortable {
+        padding-right: 0.8em;
+      }
+      #free_properties_form table th.sortable::before,
+      #free_properties_form table th.sortable::after {
+        display: none;
+      }
+      #free_properties_form table tr {
+        height: 4rem;
+      }
+      #free_properties_form table tr:nth-child(even) {
+        background-color: var(--off-folksonomy-row-even-bg, #f9f9f9);
+      }
+      @media (max-width: 480px) {
+        #free_properties_form table tr:first-child {
+          height: 0.5rem;
+        }
+      }
+    `,
+  ]
 
   /**
    * State representing all the properties and values

--- a/web-components/src/components/folksonomy/folksonomy-properties.ts
+++ b/web-components/src/components/folksonomy/folksonomy-properties.ts
@@ -7,6 +7,7 @@ import { createDebounce, downloadCSV } from "../../utils"
 import "../shared/dual-range-slider"
 import type { PropertyClashCheck } from "../../types/folksonomy"
 import { userInfo } from "../../signals/folksonomy"
+import { FOLKSONOMY_THEME } from "../../styles/folksonomy-theme"
 
 /**
  * Folksonomy Properties Viewer
@@ -16,447 +17,454 @@ import { userInfo } from "../../signals/folksonomy"
 @customElement("folksonomy-properties")
 @localized()
 export class FolksonomyProperties extends SignalWatcher(LitElement) {
-  static override styles = css`
-    :host {
-      display: block;
-      font-family: Arial, sans-serif;
-      color: #333;
-    }
-
-    .properties-container {
-      margin-bottom: 1rem;
-      background-color: #fff;
-      border: 1px solid #ddd;
-      border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      padding: 1rem;
-    }
-
-    .properties-container h2 {
-      font-size: 2.2rem;
-      font-weight: 600;
-      color: #222;
-      margin-top: 10px;
-      margin-bottom: 0.5rem;
-    }
-
-    .properties-container p {
-      font-size: 0.9rem;
-      line-height: 1.5;
-      margin-bottom: 1rem;
-      color: #222;
-    }
-
-    .properties-container a {
-      color: #341100;
-    }
-
-    .properties-table {
-      width: 100%;
-      border-collapse: collapse;
-      margin-top: 1rem;
-      border: solid 1px #ddd;
-      font-size: 0.9rem;
-    }
-
-    .properties-table th,
-    .properties-table td {
-      padding: 0.8rem;
-      text-align: left;
-      border: solid 1px #ddd;
-    }
-
-    .properties-table th {
-      background-color: #f8f9fa;
-      font-weight: bold;
-      position: sticky;
-      top: 0;
-      z-index: 1;
-    }
-
-    .properties-table tr:nth-child(even) {
-      background-color: #f9f9f9;
-    }
-
-    .properties-table tr:hover {
-      background-color: #e8f4fd;
-    }
-
-    .property-name {
-      font-weight: 500;
-      color: #341100;
-    }
-
-    .doc-link {
-      font-size: 1.1rem;
-    }
-
-    .doc-link:hover {
-      opacity: 0.7;
-    }
-
-    .count {
-      text-align: right;
-      font-weight: 500;
-    }
-
-    .values {
-      text-align: right;
-      font-weight: 500;
-    }
-
-    .loading {
-      text-align: center;
-      padding: 2rem;
-      color: #666;
-    }
-
-    .error {
-      color: #dc3545;
-      text-align: center;
-      padding: 1rem;
-      background-color: #f8d7da;
-      border: 1px solid #f5c6cb;
-      border-radius: 4px;
-      margin: 1rem 0;
-    }
-
-    .empty-state {
-      text-align: center;
-      padding: 2rem;
-      color: #666;
-    }
-
-    /* Prepare table for filtering */
-    .filter-row {
-      background-color: #f8f9fa;
-    }
-
-    .filter-input {
-      width: 100%;
-      padding: 0.25rem;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      font-size: 0.875rem;
-      box-sizing: border-box;
-    }
-
-    .filter-input:focus {
-      outline: none;
-      border-color: #007bff;
-      box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
-    }
-
-    .filter-controls {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin: 1rem 0;
-      padding: 0.5rem;
-      background-color: #f8f9fa;
-      border-radius: 4px;
-    }
-
-    .rows-counter {
-      font-size: 0.875rem;
-      color: #666;
-    }
-
-    .reset-btn {
-      background-color: #341100;
-      color: white;
-      border: 1px solid #341100;
-      padding: 0.4rem 0.8rem;
-      border-radius: 4px;
-      cursor: pointer;
-      transition:
-        background-color 0.3s,
-        color 0.3s;
-      margin-left: 1rem;
-    }
-
-    .download-btn {
-      background-color: #341100;
-      color: white;
-      border: 1px solid #341100;
-      padding: 0.4rem 0.8rem;
-      border-radius: 4px;
-      cursor: pointer;
-      transition:
-        background-color 0.3s,
-        color 0.3s;
-    }
-
-    .button-group {
-      display: flex;
-      gap: 0.5rem;
-    }
-
-    .status-bar {
-      font-size: 0.875rem;
-      color: #666;
-      font-style: italic;
-    }
-
-    .actions-column {
-      text-align: center;
-      width: 120px;
-    }
-
-    .actions-buttons {
-      display: flex;
-      gap: 0.25rem;
-      justify-content: center;
-      flex-wrap: wrap;
-    }
-
-    .action-btn {
-      background-color: transparent;
-      border: 1px solid #341100;
-      color: #341100;
-      padding: 0.25rem 0.5rem;
-      border-radius: 3px;
-      cursor: pointer;
-      font-size: 0.75rem;
-      transition: all 0.2s;
-      min-width: 50px;
-    }
-
-    .action-btn:hover {
-      background-color: #341100;
-      color: white;
-    }
-
-    .action-btn.delete {
-      border-color: #dc3545;
-      color: #dc3545;
-    }
-
-    .action-btn.delete:hover {
-      background-color: #dc3545;
-      color: white;
-    }
-
-    .action-btn:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
-
-    .action-btn:disabled:hover {
-      background-color: transparent;
-      color: #341100;
-    }
-
-    .action-btn.delete:disabled:hover {
-      background-color: transparent;
-      color: #dc3545;
-    }
-
-    /* Modal styles */
-    .modal-overlay {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background-color: rgba(0, 0, 0, 0.5);
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      z-index: 1000;
-      animation: fadeIn 0.2s ease-out;
-    }
-
-    .modal {
-      background: white;
-      border-radius: 8px;
-      box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
-      max-width: 500px;
-      width: 90%;
-      max-height: 90vh;
-      overflow-y: auto;
-      animation: slideIn 0.2s ease-out;
-    }
-
-    .modal-header {
-      padding: 1.5rem 1.5rem 0;
-      border-bottom: 1px solid #eee;
-    }
-
-    .modal-title {
-      font-size: 1.25rem;
-      font-weight: 600;
-      color: #333;
-      margin: 0 0 1rem 0;
-    }
-
-    .modal-body {
-      padding: 1.5rem;
-    }
-
-    .modal-footer {
-      padding: 0 1.5rem 1.5rem;
-      display: flex;
-      gap: 0.75rem;
-      justify-content: flex-end;
-    }
-
-    .modal-input {
-      width: 100%;
-      padding: 0.75rem;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      font-size: 1rem;
-      margin-top: 0.5rem;
-    }
-
-    .modal-input:focus {
-      outline: none;
-      border-color: #341100;
-      box-shadow: 0 0 0 2px rgba(52, 17, 0, 0.1);
-    }
-
-    .modal-text {
-      color: #555;
-      line-height: 1.5;
-      margin-bottom: 1rem;
-    }
-
-    .modal-btn {
-      padding: 0.75rem 1.5rem;
-      border: none;
-      border-radius: 4px;
-      font-size: 0.9rem;
-      font-weight: 500;
-      cursor: pointer;
-      transition: all 0.2s;
-      min-width: 80px;
-    }
-
-    .modal-btn-primary {
-      background-color: #341100;
-      color: white;
-    }
-
-    .modal-btn-primary:hover {
-      background-color: #2a0e00;
-    }
-
-    .modal-btn-danger {
-      background-color: #dc3545;
-      color: white;
-    }
-
-    .modal-btn-danger:hover {
-      background-color: #c82333;
-    }
-
-    .modal-btn-secondary {
-      background-color: #f8f9fa;
-      color: #333;
-      border: 1px solid #ddd;
-    }
-
-    .modal-btn-secondary:hover {
-      background-color: #e9ecef;
-    }
-
-    .modal-btn:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
-
-    .clash-info {
-      background-color: #fff3cd;
-      border: 1px solid #ffeaa7;
-      border-radius: 4px;
-      padding: 1rem;
-      margin: 1rem 0;
-    }
-
-    .clash-stat {
-      display: flex;
-      justify-content: space-between;
-      margin: 0.5rem 0;
-    }
-
-    .clash-stat-label {
-      font-weight: 500;
-    }
-
-    .clash-stat-value {
-      font-weight: bold;
-      color: #856404;
-    }
-
-    @keyframes fadeIn {
-      from {
-        opacity: 0;
+  static override styles = [
+    FOLKSONOMY_THEME,
+    css`
+      :host {
+        display: block;
+        font-family: Arial, sans-serif;
+        color: var(--off-folksonomy-text, #333);
       }
-      to {
-        opacity: 1;
-      }
-    }
 
-    @keyframes slideIn {
-      from {
-        opacity: 0;
-        transform: translateY(-20px);
+      .properties-container {
+        margin-bottom: 1rem;
+        background-color: var(--off-folksonomy-bg, #fff);
+        border: 1px solid var(--off-folksonomy-border, #ddd);
+        border-radius: 8px;
+        box-shadow: 0 2px 4px var(--off-folksonomy-shadow, rgba(0, 0, 0, 0.1));
+        padding: 1rem;
       }
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
 
-    /* Mobile responsiveness */
-    @media (max-width: 768px) {
+      .properties-container h2 {
+        font-size: 2.2rem;
+        font-weight: 600;
+        color: var(--off-folksonomy-text-secondary, #222);
+        margin-top: 10px;
+        margin-bottom: 0.5rem;
+      }
+
+      .properties-container p {
+        font-size: 0.9rem;
+        line-height: 1.5;
+        margin-bottom: 1rem;
+        color: var(--off-folksonomy-text-secondary, #222);
+      }
+
+      .properties-container a {
+        color: var(--off-folksonomy-accent, #341100);
+      }
+
       .properties-table {
-        font-size: 0.8rem;
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+        border: solid 1px var(--off-folksonomy-border, #ddd);
+        font-size: 0.9rem;
       }
 
       .properties-table th,
       .properties-table td {
+        padding: 0.8rem;
+        text-align: left;
+        border: solid 1px var(--off-folksonomy-border, #ddd);
+      }
+
+      .properties-table th {
+        background-color: var(--off-folksonomy-table-header-bg-alt, #f8f9fa);
+        font-weight: bold;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+      }
+
+      .properties-table tr:nth-child(even) {
+        background-color: var(--off-folksonomy-row-even-bg, #f9f9f9);
+      }
+
+      .properties-table tr:hover {
+        background-color: var(--off-folksonomy-row-hover-bg, #e8f4fd);
+      }
+
+      .property-name {
+        font-weight: 500;
+        color: var(--off-folksonomy-accent, #341100);
+      }
+
+      .doc-link {
+        font-size: 1.1rem;
+      }
+
+      .doc-link:hover {
+        opacity: 0.7;
+      }
+
+      .count {
+        text-align: right;
+        font-weight: 500;
+      }
+
+      .values {
+        text-align: right;
+        font-weight: 500;
+      }
+
+      .loading {
+        text-align: center;
+        padding: 2rem;
+        color: var(--off-folksonomy-loading-text, #666);
+      }
+
+      .error {
+        color: var(--off-folksonomy-danger, #dc3545);
+        text-align: center;
+        padding: 1rem;
+        background-color: var(--off-folksonomy-error-bg, #f8d7da);
+        border: 1px solid var(--off-folksonomy-error-border, #f5c6cb);
+        border-radius: 4px;
+        margin: 1rem 0;
+      }
+
+      .empty-state {
+        text-align: center;
+        padding: 2rem;
+        color: var(--off-folksonomy-loading-text, #666);
+      }
+
+      /* Prepare table for filtering */
+      .filter-row {
+        background-color: var(--off-folksonomy-filter-bg, #f8f9fa);
+      }
+
+      .filter-input {
+        width: 100%;
+        padding: 0.25rem;
+        border: 1px solid var(--off-folksonomy-border, #ddd);
+        border-radius: 4px;
+        font-size: 0.875rem;
+        box-sizing: border-box;
+        background-color: var(--off-folksonomy-input-bg, rgb(252, 251, 251));
+        color: var(--off-folksonomy-text, #333);
+      }
+
+      .filter-input:focus {
+        outline: none;
+        border-color: var(--off-folksonomy-input-focus-border, #007bff);
+        box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+      }
+
+      .filter-controls {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin: 1rem 0;
         padding: 0.5rem;
+        background-color: var(--off-folksonomy-filter-bg, #f8f9fa);
+        border-radius: 4px;
       }
 
-      .properties-container h2 {
-        font-size: 1.8rem;
+      .rows-counter {
+        font-size: 0.875rem;
+        color: var(--off-folksonomy-loading-text, #666);
       }
 
-      .properties-container p {
-        font-size: 0.8rem;
+      .reset-btn {
+        background-color: var(--off-folksonomy-accent, #341100);
+        color: white;
+        border: 1px solid var(--off-folksonomy-accent, #341100);
+        padding: 0.4rem 0.8rem;
+        border-radius: 4px;
+        cursor: pointer;
+        transition:
+          background-color 0.3s,
+          color 0.3s;
+        margin-left: 1rem;
+      }
+
+      .download-btn {
+        background-color: var(--off-folksonomy-accent, #341100);
+        color: white;
+        border: 1px solid var(--off-folksonomy-accent, #341100);
+        padding: 0.4rem 0.8rem;
+        border-radius: 4px;
+        cursor: pointer;
+        transition:
+          background-color 0.3s,
+          color 0.3s;
+      }
+
+      .button-group {
+        display: flex;
+        gap: 0.5rem;
+      }
+
+      .status-bar {
+        font-size: 0.875rem;
+        color: var(--off-folksonomy-loading-text, #666);
+        font-style: italic;
       }
 
       .actions-column {
-        width: 100px;
+        text-align: center;
+        width: 120px;
       }
 
       .actions-buttons {
-        flex-direction: column;
-        gap: 0.125rem;
+        display: flex;
+        gap: 0.25rem;
+        justify-content: center;
+        flex-wrap: wrap;
       }
 
       .action-btn {
-        font-size: 0.7rem;
-        padding: 0.2rem 0.4rem;
-        min-width: 40px;
+        background-color: transparent;
+        border: 1px solid var(--off-folksonomy-accent, #341100);
+        color: var(--off-folksonomy-accent, #341100);
+        padding: 0.25rem 0.5rem;
+        border-radius: 3px;
+        cursor: pointer;
+        font-size: 0.75rem;
+        transition: all 0.2s;
+        min-width: 50px;
+      }
+
+      .action-btn:hover {
+        background-color: var(--off-folksonomy-accent, #341100);
+        color: white;
+      }
+
+      .action-btn.delete {
+        border-color: var(--off-folksonomy-danger, #dc3545);
+        color: var(--off-folksonomy-danger, #dc3545);
+      }
+
+      .action-btn.delete:hover {
+        background-color: var(--off-folksonomy-danger, #dc3545);
+        color: white;
+      }
+
+      .action-btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .action-btn:disabled:hover {
+        background-color: transparent;
+        color: var(--off-folksonomy-accent, #341100);
+      }
+
+      .action-btn.delete:disabled:hover {
+        background-color: transparent;
+        color: var(--off-folksonomy-danger, #dc3545);
+      }
+
+      /* Modal styles */
+      .modal-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: rgba(0, 0, 0, 0.5);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 1000;
+        animation: fadeIn 0.2s ease-out;
       }
 
       .modal {
-        width: 95%;
-        margin: 1rem;
+        background: var(--off-folksonomy-modal-bg, white);
+        border-radius: 8px;
+        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+        max-width: 500px;
+        width: 90%;
+        max-height: 90vh;
+        overflow-y: auto;
+        animation: slideIn 0.2s ease-out;
+      }
+
+      .modal-header {
+        padding: 1.5rem 1.5rem 0;
+        border-bottom: 1px solid var(--off-folksonomy-modal-header-border, #eee);
+      }
+
+      .modal-title {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--off-folksonomy-modal-text, #333);
+        margin: 0 0 1rem 0;
+      }
+
+      .modal-body {
+        padding: 1.5rem;
       }
 
       .modal-footer {
-        flex-direction: column;
+        padding: 0 1.5rem 1.5rem;
+        display: flex;
+        gap: 0.75rem;
+        justify-content: flex-end;
+      }
+
+      .modal-input {
+        width: 100%;
+        padding: 0.75rem;
+        border: 1px solid var(--off-folksonomy-border, #ddd);
+        border-radius: 4px;
+        font-size: 1rem;
+        margin-top: 0.5rem;
+        background-color: var(--off-folksonomy-input-bg, rgb(252, 251, 251));
+        color: var(--off-folksonomy-text, #333);
+      }
+
+      .modal-input:focus {
+        outline: none;
+        border-color: var(--off-folksonomy-accent, #341100);
+        box-shadow: 0 0 0 2px rgba(52, 17, 0, 0.1);
+      }
+
+      .modal-text {
+        color: var(--off-folksonomy-modal-text-secondary, #555);
+        line-height: 1.5;
+        margin-bottom: 1rem;
       }
 
       .modal-btn {
-        width: 100%;
+        padding: 0.75rem 1.5rem;
+        border: none;
+        border-radius: 4px;
+        font-size: 0.9rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+        min-width: 80px;
       }
-    }
-  `
+
+      .modal-btn-primary {
+        background-color: var(--off-folksonomy-accent, #341100);
+        color: white;
+      }
+
+      .modal-btn-primary:hover {
+        background-color: var(--off-folksonomy-accent-hover, #2a0e00);
+      }
+
+      .modal-btn-danger {
+        background-color: var(--off-folksonomy-danger, #dc3545);
+        color: white;
+      }
+
+      .modal-btn-danger:hover {
+        background-color: var(--off-folksonomy-danger-hover, #c82333);
+      }
+
+      .modal-btn-secondary {
+        background-color: var(--off-folksonomy-btn-secondary-bg, #f8f9fa);
+        color: var(--off-folksonomy-modal-text, #333);
+        border: 1px solid var(--off-folksonomy-border, #ddd);
+      }
+
+      .modal-btn-secondary:hover {
+        background-color: var(--off-folksonomy-btn-secondary-hover, #e9ecef);
+      }
+
+      .modal-btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .clash-info {
+        background-color: var(--off-folksonomy-clash-bg, #fff3cd);
+        border: 1px solid var(--off-folksonomy-clash-border, #ffeaa7);
+        border-radius: 4px;
+        padding: 1rem;
+        margin: 1rem 0;
+      }
+
+      .clash-stat {
+        display: flex;
+        justify-content: space-between;
+        margin: 0.5rem 0;
+      }
+
+      .clash-stat-label {
+        font-weight: 500;
+      }
+
+      .clash-stat-value {
+        font-weight: bold;
+        color: var(--off-folksonomy-clash-value, #856404);
+      }
+
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
+      }
+
+      @keyframes slideIn {
+        from {
+          opacity: 0;
+          transform: translateY(-20px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      /* Mobile responsiveness */
+      @media (max-width: 768px) {
+        .properties-table {
+          font-size: 0.8rem;
+        }
+
+        .properties-table th,
+        .properties-table td {
+          padding: 0.5rem;
+        }
+
+        .properties-container h2 {
+          font-size: 1.8rem;
+        }
+
+        .properties-container p {
+          font-size: 0.8rem;
+        }
+
+        .actions-column {
+          width: 100px;
+        }
+
+        .actions-buttons {
+          flex-direction: column;
+          gap: 0.125rem;
+        }
+
+        .action-btn {
+          font-size: 0.7rem;
+          padding: 0.2rem 0.4rem;
+          min-width: 40px;
+        }
+
+        .modal {
+          width: 95%;
+          margin: 1rem;
+        }
+
+        .modal-footer {
+          flex-direction: column;
+        }
+
+        .modal-btn {
+          width: 100%;
+        }
+      }
+    `,
+  ]
 
   /**
    * Path to single property, the property name is appended to the end.

--- a/web-components/src/components/folksonomy/folksonomy-property-products.ts
+++ b/web-components/src/components/folksonomy/folksonomy-property-products.ts
@@ -5,6 +5,7 @@ import { localized, msg, str } from "@lit/localize"
 import { SignalWatcher } from "@lit-labs/signals"
 import folksonomyApi from "../../api/folksonomy"
 import { userInfo } from "../../signals/folksonomy"
+import { FOLKSONOMY_THEME } from "../../styles/folksonomy-theme"
 
 /**
  * Folksonomy Property Products Viewer
@@ -15,527 +16,535 @@ import { userInfo } from "../../signals/folksonomy"
 @customElement("folksonomy-property-products")
 @localized()
 export class FolksonomyPropertyProducts extends SignalWatcher(LitElement) {
-  static override styles = css`
-    :host {
-      font-family: Arial, sans-serif;
-      color: #333;
-    }
+  static override styles = [
+    FOLKSONOMY_THEME,
+    css`
+      :host {
+        font-family: Arial, sans-serif;
+        color: var(--off-folksonomy-text, #333);
+      }
 
-    .property-container {
-      margin: 0 auto 1rem auto;
-      background-color: #fff;
-      border: 1px solid #ddd;
-      border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      padding: 1rem;
-      box-sizing: border-box;
-    }
+      .property-container {
+        margin: 0 auto 1rem auto;
+        background-color: var(--off-folksonomy-bg, #fff);
+        border: 1px solid var(--off-folksonomy-border, #ddd);
+        border-radius: 8px;
+        box-shadow: 0 2px 4px var(--off-folksonomy-shadow, rgba(0, 0, 0, 0.1));
+        padding: 1rem;
+        box-sizing: border-box;
+      }
 
-    .property-container h2 {
-      font-size: 2.2rem;
-      font-weight: 400;
-      color: #222;
-      margin-top: 10px;
-      margin-bottom: 0.5rem;
-    }
+      .property-container h2 {
+        font-size: 2.2rem;
+        font-weight: 400;
+        color: var(--off-folksonomy-text-secondary, #222);
+        margin-top: 10px;
+        margin-bottom: 0.5rem;
+      }
 
-    .property-container p {
-      font-size: 0.9rem;
-      line-height: 1.5;
-      margin-bottom: 1rem;
-      color: #222;
-    }
+      .property-container p {
+        font-size: 0.9rem;
+        line-height: 1.5;
+        margin-bottom: 1rem;
+        color: var(--off-folksonomy-text-secondary, #222);
+      }
 
-    .property-container a {
-      color: #341100;
-    }
+      .property-container a {
+        color: var(--off-folksonomy-accent, #341100);
+      }
 
-    .content-wrapper {
-      display: flex;
-      gap: 1rem;
-      align-items: flex-start;
-    }
-
-    .main-content {
-      flex: 1;
-      min-width: 0;
-    }
-
-    .header-section {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      margin-bottom: 1rem;
-    }
-
-    .property-title-container {
-      flex: 1;
-      min-width: 0;
-    }
-
-    .info-box {
-      margin-top: 10px;
-      align-self: flex-start;
-    }
-
-    .table-container {
-      width: 100%;
-      max-width: 1200px;
-      margin: 0 auto;
-    }
-
-    .products-table {
-      width: 100%;
-      border-collapse: collapse;
-      margin-top: 1rem;
-      border: solid 1px #ddd;
-      font-size: 0.9rem;
-    }
-
-    .products-table th,
-    .products-table td {
-      padding: 0.8rem;
-      text-align: left;
-      border: solid 1px #ddd;
-    }
-
-    .products-table th {
-      background-color: #f8f9fa;
-      font-weight: bold;
-      position: sticky;
-      top: 0;
-      z-index: 1;
-    }
-
-    .products-table tr:nth-child(even) {
-      background-color: #f9f9f9;
-    }
-
-    .products-table tr:hover {
-      background-color: #e8f4fd;
-    }
-
-    .product-code {
-      font-weight: 500;
-      color: #341100;
-    }
-
-    .property-value {
-      font-weight: 500;
-      color: #341100;
-    }
-
-    .count {
-      text-align: right;
-      font-weight: bold;
-      color: #333;
-    }
-
-    .count-header {
-      text-align: right;
-    }
-
-    .loading {
-      text-align: center;
-      padding: 2rem;
-      color: #666;
-    }
-
-    .error {
-      color: #dc3545;
-      text-align: center;
-      padding: 1rem;
-      background-color: #f8d7da;
-      border: 1px solid #f5c6cb;
-      border-radius: 4px;
-      margin: 1rem 0;
-    }
-
-    .empty-state {
-      text-align: center;
-      padding: 2rem;
-      color: #666;
-    }
-
-    /* Filter styles */
-    .filter-row {
-      background-color: #f8f9fa;
-    }
-
-    .filter-input {
-      width: 100%;
-      padding: 0.25rem;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      font-size: 0.875rem;
-      box-sizing: border-box;
-    }
-
-    .filter-input:focus {
-      outline: none;
-      border-color: #007bff;
-      box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
-    }
-
-    .filter-controls {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin: 1rem 0;
-      padding: 0.5rem;
-      background-color: #f8f9fa;
-      border-radius: 4px;
-    }
-
-    .rows-counter {
-      font-size: 0.875rem;
-      color: #666;
-    }
-
-    .download-btn {
-      background-color: #341100;
-      color: white;
-      border: 1px solid #341100;
-      padding: 0.4rem 0.8rem;
-      border-radius: 4px;
-      cursor: pointer;
-      transition:
-        background-color 0.3s,
-        color 0.3s;
-    }
-
-    .download-btn:hover {
-      background-color: rgb(255, 255, 255);
-      color: #341100;
-      border: 1px solid #341100;
-    }
-
-    .reset-btn {
-      background-color: #341100;
-      color: white;
-      border: 1px solid #341100;
-      padding: 0.4rem 0.8rem;
-      border-radius: 4px;
-      cursor: pointer;
-      transition:
-        background-color 0.3s,
-        color 0.3s;
-      margin-left: 1rem;
-    }
-
-    .reset-btn:hover {
-      background-color: rgb(255, 255, 255);
-      color: #341100;
-      border: 1px solid #341100;
-    }
-
-    .button-group {
-      display: flex;
-      gap: 0.5rem;
-    }
-
-    .view-mode-toggle {
-      display: flex;
-      background-color: #f8f9fa;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      overflow: hidden;
-    }
-
-    .view-mode-btn {
-      background-color: transparent;
-      border: none;
-      padding: 0.4rem 0.8rem;
-      cursor: pointer;
-      transition: background-color 0.2s;
-      font-size: 0.875rem;
-    }
-
-    .view-mode-btn:hover {
-      background-color: #e9ecef;
-    }
-
-    .view-mode-btn.active {
-      background-color: #341100;
-      color: white;
-    }
-
-    .view-controls {
-      display: flex;
-      align-items: center;
-      gap: 1rem;
-    }
-
-    /* Mobile responsiveness */
-    @media (max-width: 768px) {
       .content-wrapper {
-        flex-direction: column;
+        display: flex;
+        gap: 1rem;
+        align-items: flex-start;
+      }
+
+      .main-content {
+        flex: 1;
+        min-width: 0;
       }
 
       .header-section {
-        flex-direction: column;
-        gap: 1rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        margin-bottom: 1rem;
+      }
+
+      .property-title-container {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .info-box {
+        margin-top: 10px;
+        align-self: flex-start;
+      }
+
+      .table-container {
+        width: 100%;
+        max-width: 1200px;
+        margin: 0 auto;
       }
 
       .products-table {
-        font-size: 0.8rem;
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+        border: solid 1px var(--off-folksonomy-border, #ddd);
+        font-size: 0.9rem;
       }
 
       .products-table th,
       .products-table td {
-        padding: 0.5rem;
+        padding: 0.8rem;
+        text-align: left;
+        border: solid 1px var(--off-folksonomy-border, #ddd);
       }
 
-      .property-container h2 {
-        font-size: 1.8rem;
+      .products-table th {
+        background-color: var(--off-folksonomy-table-header-bg-alt, #f8f9fa);
+        font-weight: bold;
+        position: sticky;
+        top: 0;
+        z-index: 1;
       }
 
-      .property-container p {
-        font-size: 0.8rem;
+      .products-table tr:nth-child(even) {
+        background-color: var(--off-folksonomy-row-even-bg, #f9f9f9);
+      }
+
+      .products-table tr:hover {
+        background-color: var(--off-folksonomy-row-hover-bg, #e8f4fd);
+      }
+
+      .product-code {
+        font-weight: 500;
+        color: var(--off-folksonomy-accent, #341100);
+      }
+
+      .property-value {
+        font-weight: 500;
+        color: var(--off-folksonomy-accent, #341100);
+      }
+
+      .count {
+        text-align: right;
+        font-weight: bold;
+        color: var(--off-folksonomy-text, #333);
+      }
+
+      .count-header {
+        text-align: right;
+      }
+
+      .loading {
+        text-align: center;
+        padding: 2rem;
+        color: var(--off-folksonomy-loading-text, #666);
+      }
+
+      .error {
+        color: var(--off-folksonomy-danger, #dc3545);
+        text-align: center;
+        padding: 1rem;
+        background-color: var(--off-folksonomy-error-bg, #f8d7da);
+        border: 1px solid var(--off-folksonomy-error-border, #f5c6cb);
+        border-radius: 4px;
+        margin: 1rem 0;
+      }
+
+      .empty-state {
+        text-align: center;
+        padding: 2rem;
+        color: var(--off-folksonomy-loading-text, #666);
+      }
+
+      /* Filter styles */
+      .filter-row {
+        background-color: var(--off-folksonomy-filter-bg, #f8f9fa);
+      }
+
+      .filter-input {
+        width: 100%;
+        padding: 0.25rem;
+        border: 1px solid var(--off-folksonomy-border, #ddd);
+        border-radius: 4px;
+        font-size: 0.875rem;
+        box-sizing: border-box;
+        background-color: var(--off-folksonomy-input-bg, rgb(252, 251, 251));
+        color: var(--off-folksonomy-text, #333);
+      }
+
+      .filter-input:focus {
+        outline: none;
+        border-color: var(--off-folksonomy-input-focus-border, #007bff);
+        box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
       }
 
       .filter-controls {
-        flex-direction: column;
-        gap: 1rem;
-        align-items: stretch;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin: 1rem 0;
+        padding: 0.5rem;
+        background-color: var(--off-folksonomy-filter-bg, #f8f9fa);
+        border-radius: 4px;
       }
 
-      .view-controls {
-        flex-direction: column;
+      .rows-counter {
+        font-size: 0.875rem;
+        color: var(--off-folksonomy-loading-text, #666);
+      }
+
+      .download-btn {
+        background-color: var(--off-folksonomy-accent, #341100);
+        color: white;
+        border: 1px solid var(--off-folksonomy-accent, #341100);
+        padding: 0.4rem 0.8rem;
+        border-radius: 4px;
+        cursor: pointer;
+        transition:
+          background-color 0.3s,
+          color 0.3s;
+      }
+
+      .download-btn:hover {
+        background-color: var(--off-folksonomy-bg, rgb(255, 255, 255));
+        color: var(--off-folksonomy-accent, #341100);
+        border: 1px solid var(--off-folksonomy-accent, #341100);
+      }
+
+      .reset-btn {
+        background-color: var(--off-folksonomy-accent, #341100);
+        color: white;
+        border: 1px solid var(--off-folksonomy-accent, #341100);
+        padding: 0.4rem 0.8rem;
+        border-radius: 4px;
+        cursor: pointer;
+        transition:
+          background-color 0.3s,
+          color 0.3s;
+        margin-left: 1rem;
+      }
+
+      .reset-btn:hover {
+        background-color: var(--off-folksonomy-bg, rgb(255, 255, 255));
+        color: var(--off-folksonomy-accent, #341100);
+        border: 1px solid var(--off-folksonomy-accent, #341100);
+      }
+
+      .button-group {
+        display: flex;
         gap: 0.5rem;
-        align-items: center;
       }
 
       .view-mode-toggle {
-        width: 100%;
-        max-width: 300px;
+        display: flex;
+        background-color: var(--off-folksonomy-filter-bg, #f8f9fa);
+        border: 1px solid var(--off-folksonomy-border, #ddd);
+        border-radius: 4px;
+        overflow: hidden;
       }
 
       .view-mode-btn {
-        flex: 1;
+        background-color: transparent;
+        border: none;
+        padding: 0.4rem 0.8rem;
+        cursor: pointer;
+        transition: background-color 0.2s;
+        font-size: 0.875rem;
+        color: var(--off-folksonomy-text, #333);
       }
-    }
 
-    .actions-column {
-      text-align: center;
-      width: 120px;
-    }
+      .view-mode-btn:hover {
+        background-color: var(--off-folksonomy-btn-secondary-hover, #e9ecef);
+      }
 
-    .actions-buttons {
-      display: flex;
-      gap: 0.25rem;
-      justify-content: center;
-      flex-wrap: wrap;
-    }
+      .view-mode-btn.active {
+        background-color: var(--off-folksonomy-accent, #341100);
+        color: white;
+      }
 
-    .action-btn {
-      background-color: transparent;
-      border: 1px solid #341100;
-      color: #341100;
-      padding: 0.25rem 0.5rem;
-      border-radius: 3px;
-      cursor: pointer;
-      font-size: 0.75rem;
-      transition: all 0.2s;
-      min-width: 50px;
-    }
+      .view-controls {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
 
-    .action-btn:hover {
-      background-color: #341100;
-      color: white;
-    }
+      /* Mobile responsiveness */
+      @media (max-width: 768px) {
+        .content-wrapper {
+          flex-direction: column;
+        }
 
-    .action-btn.delete {
-      border-color: #dc3545;
-      color: #dc3545;
-    }
+        .header-section {
+          flex-direction: column;
+          gap: 1rem;
+        }
 
-    .action-btn.delete:hover {
-      background-color: #dc3545;
-      color: white;
-    }
+        .products-table {
+          font-size: 0.8rem;
+        }
 
-    .action-btn:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
+        .products-table th,
+        .products-table td {
+          padding: 0.5rem;
+        }
 
-    .action-btn:disabled:hover {
-      background-color: transparent;
-      color: #341100;
-    }
+        .property-container h2 {
+          font-size: 1.8rem;
+        }
 
-    .action-btn.delete:disabled:hover {
-      background-color: transparent;
-      color: #dc3545;
-    }
+        .property-container p {
+          font-size: 0.8rem;
+        }
 
-    @media (max-width: 768px) {
+        .filter-controls {
+          flex-direction: column;
+          gap: 1rem;
+          align-items: stretch;
+        }
+
+        .view-controls {
+          flex-direction: column;
+          gap: 0.5rem;
+          align-items: center;
+        }
+
+        .view-mode-toggle {
+          width: 100%;
+          max-width: 300px;
+        }
+
+        .view-mode-btn {
+          flex: 1;
+        }
+      }
+
       .actions-column {
-        width: 100px;
+        text-align: center;
+        width: 120px;
       }
 
       .actions-buttons {
-        flex-direction: column;
-        gap: 0.125rem;
+        display: flex;
+        gap: 0.25rem;
+        justify-content: center;
+        flex-wrap: wrap;
       }
 
       .action-btn {
-        font-size: 0.7rem;
-        padding: 0.2rem 0.4rem;
-        min-width: 40px;
+        background-color: transparent;
+        border: 1px solid var(--off-folksonomy-accent, #341100);
+        color: var(--off-folksonomy-accent, #341100);
+        padding: 0.25rem 0.5rem;
+        border-radius: 3px;
+        cursor: pointer;
+        font-size: 0.75rem;
+        transition: all 0.2s;
+        min-width: 50px;
       }
-    }
 
-    /* Modal styles */
-    .modal-overlay {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background-color: rgba(0, 0, 0, 0.5);
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      z-index: 1000;
-      animation: fadeIn 0.2s ease-out;
-    }
-
-    .modal {
-      background: white;
-      border-radius: 8px;
-      box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
-      max-width: 500px;
-      width: 90%;
-      max-height: 90vh;
-      overflow-y: auto;
-      animation: slideIn 0.2s ease-out;
-    }
-
-    .modal-header {
-      padding: 1.5rem 1.5rem 0;
-      border-bottom: 1px solid #eee;
-    }
-
-    .modal-title {
-      font-size: 1.25rem;
-      font-weight: 600;
-      color: #333;
-      margin: 0 0 1rem 0;
-    }
-
-    .modal-body {
-      padding: 1.5rem;
-    }
-
-    .modal-footer {
-      padding: 0 1.5rem 1.5rem;
-      display: flex;
-      gap: 0.75rem;
-      justify-content: flex-end;
-    }
-
-    .modal-input {
-      width: 100%;
-      padding: 0.75rem;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      font-size: 1rem;
-      margin-top: 0.5rem;
-    }
-
-    .modal-input:focus {
-      outline: none;
-      border-color: #341100;
-      box-shadow: 0 0 0 2px rgba(52, 17, 0, 0.1);
-    }
-
-    .modal-text {
-      color: #555;
-      line-height: 1.5;
-      margin-bottom: 1rem;
-    }
-
-    .modal-btn {
-      padding: 0.75rem 1.5rem;
-      border: none;
-      border-radius: 4px;
-      font-size: 0.9rem;
-      font-weight: 500;
-      cursor: pointer;
-      transition: all 0.2s;
-      min-width: 80px;
-    }
-
-    .modal-btn-primary {
-      background-color: #341100;
-      color: white;
-    }
-
-    .modal-btn-primary:hover {
-      background-color: #2a0e00;
-    }
-
-    .modal-btn-danger {
-      background-color: #dc3545;
-      color: white;
-    }
-
-    .modal-btn-danger:hover {
-      background-color: #c82333;
-    }
-
-    .modal-btn-secondary {
-      background-color: #f8f9fa;
-      color: #333;
-      border: 1px solid #ddd;
-    }
-
-    .modal-btn-secondary:hover {
-      background-color: #e9ecef;
-    }
-
-    .modal-btn:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
-
-    @keyframes fadeIn {
-      from {
-        opacity: 0;
+      .action-btn:hover {
+        background-color: var(--off-folksonomy-accent, #341100);
+        color: white;
       }
-      to {
-        opacity: 1;
-      }
-    }
 
-    @keyframes slideIn {
-      from {
-        opacity: 0;
-        transform: translateY(-20px);
+      .action-btn.delete {
+        border-color: var(--off-folksonomy-danger, #dc3545);
+        color: var(--off-folksonomy-danger, #dc3545);
       }
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
 
-    @media (max-width: 768px) {
+      .action-btn.delete:hover {
+        background-color: var(--off-folksonomy-danger, #dc3545);
+        color: white;
+      }
+
+      .action-btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .action-btn:disabled:hover {
+        background-color: transparent;
+        color: var(--off-folksonomy-accent, #341100);
+      }
+
+      .action-btn.delete:disabled:hover {
+        background-color: transparent;
+        color: var(--off-folksonomy-danger, #dc3545);
+      }
+
+      @media (max-width: 768px) {
+        .actions-column {
+          width: 100px;
+        }
+
+        .actions-buttons {
+          flex-direction: column;
+          gap: 0.125rem;
+        }
+
+        .action-btn {
+          font-size: 0.7rem;
+          padding: 0.2rem 0.4rem;
+          min-width: 40px;
+        }
+      }
+
+      /* Modal styles */
+      .modal-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: rgba(0, 0, 0, 0.5);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 1000;
+        animation: fadeIn 0.2s ease-out;
+      }
+
       .modal {
-        width: 95%;
-        margin: 1rem;
+        background: var(--off-folksonomy-modal-bg, white);
+        border-radius: 8px;
+        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+        max-width: 500px;
+        width: 90%;
+        max-height: 90vh;
+        overflow-y: auto;
+        animation: slideIn 0.2s ease-out;
+      }
+
+      .modal-header {
+        padding: 1.5rem 1.5rem 0;
+        border-bottom: 1px solid var(--off-folksonomy-modal-header-border, #eee);
+      }
+
+      .modal-title {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--off-folksonomy-modal-text, #333);
+        margin: 0 0 1rem 0;
+      }
+
+      .modal-body {
+        padding: 1.5rem;
       }
 
       .modal-footer {
-        flex-direction: column;
+        padding: 0 1.5rem 1.5rem;
+        display: flex;
+        gap: 0.75rem;
+        justify-content: flex-end;
+      }
+
+      .modal-input {
+        width: 100%;
+        padding: 0.75rem;
+        border: 1px solid var(--off-folksonomy-border, #ddd);
+        border-radius: 4px;
+        font-size: 1rem;
+        margin-top: 0.5rem;
+        background-color: var(--off-folksonomy-input-bg, rgb(252, 251, 251));
+        color: var(--off-folksonomy-text, #333);
+      }
+
+      .modal-input:focus {
+        outline: none;
+        border-color: var(--off-folksonomy-accent, #341100);
+        box-shadow: 0 0 0 2px rgba(52, 17, 0, 0.1);
+      }
+
+      .modal-text {
+        color: var(--off-folksonomy-modal-text-secondary, #555);
+        line-height: 1.5;
+        margin-bottom: 1rem;
       }
 
       .modal-btn {
-        width: 100%;
+        padding: 0.75rem 1.5rem;
+        border: none;
+        border-radius: 4px;
+        font-size: 0.9rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+        min-width: 80px;
       }
-    }
-  `
+
+      .modal-btn-primary {
+        background-color: var(--off-folksonomy-accent, #341100);
+        color: white;
+      }
+
+      .modal-btn-primary:hover {
+        background-color: var(--off-folksonomy-accent-hover, #2a0e00);
+      }
+
+      .modal-btn-danger {
+        background-color: var(--off-folksonomy-danger, #dc3545);
+        color: white;
+      }
+
+      .modal-btn-danger:hover {
+        background-color: var(--off-folksonomy-danger-hover, #c82333);
+      }
+
+      .modal-btn-secondary {
+        background-color: var(--off-folksonomy-btn-secondary-bg, #f8f9fa);
+        color: var(--off-folksonomy-modal-text, #333);
+        border: 1px solid var(--off-folksonomy-border, #ddd);
+      }
+
+      .modal-btn-secondary:hover {
+        background-color: var(--off-folksonomy-btn-secondary-hover, #e9ecef);
+      }
+
+      .modal-btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
+      }
+
+      @keyframes slideIn {
+        from {
+          opacity: 0;
+          transform: translateY(-20px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      @media (max-width: 768px) {
+        .modal {
+          width: 95%;
+          margin: 1rem;
+        }
+
+        .modal-footer {
+          flex-direction: column;
+        }
+
+        .modal-btn {
+          width: 100%;
+        }
+      }
+    `,
+  ]
 
   /**
    * The property name for which we will display barcodes and values

--- a/web-components/src/components/folksonomy/new-key-modal.ts
+++ b/web-components/src/components/folksonomy/new-key-modal.ts
@@ -6,6 +6,7 @@ import {
   FolksnomyEngineDocumentationLink,
   FolksnomyEnginePropertyLink,
 } from "../../utils"
+import { FOLKSONOMY_THEME } from "../../styles/folksonomy-theme"
 
 /**
  * New Key Modal Component
@@ -17,182 +18,188 @@ import {
 export class NewKeyModal extends LitElement {
   @state()
   private propertyName = ""
-  static override styles = css`
-    .modal-overlay {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background: rgba(0, 0, 0, 0.5);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      z-index: 10000;
-    }
+  static override styles = [
+    FOLKSONOMY_THEME,
+    css`
+      .modal-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.5);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 10000;
+      }
 
-    .modal-content {
-      background: white;
-      padding: 2rem;
-      border-radius: 8px;
-      max-width: 600px;
-      width: 90%;
-      max-height: 80vh;
-      overflow-y: auto;
-      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
-    }
-
-    .modal-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin-bottom: 1.5rem;
-      padding-bottom: 1rem;
-      border-bottom: 1px solid #e0e0e0;
-    }
-
-    .modal-title {
-      font-size: 1.5rem;
-      font-weight: 600;
-      color: #333;
-      margin: 0;
-    }
-
-    .close-button {
-      background: none;
-      border: none;
-      font-size: 1.5rem;
-      cursor: pointer;
-      color: #666;
-      padding: 0.5rem;
-      border-radius: 4px;
-      transition: background-color 0.2s;
-    }
-
-    .close-button:hover {
-      background-color: #f0f0f0;
-    }
-
-    .property-input-section {
-      margin-bottom: 1.5rem;
-      padding: 1rem;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-    }
-
-    .property-input-container {
-      align-items: flex-end;
-    }
-
-    .input-group {
-      flex: 1;
-    }
-
-    .input-label {
-      display: block;
-      margin-bottom: 0.5rem;
-      font-weight: 500;
-    }
-
-    .property-input {
-      width: 100%;
-      padding: 0.5rem;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      font-size: 1rem;
-    }
-
-    .property-input:focus {
-      outline: none;
-      border-color: #007bff;
-    }
-
-    .create-wiki-button {
-      margin-top: 4px;
-      background: #007bff;
-      color: white;
-      border: none;
-      padding: 0.5rem 1rem;
-      border-radius: 4px;
-      cursor: pointer;
-    }
-
-    .create-wiki-button:hover:not(:disabled) {
-      background: #0056b3;
-    }
-
-    .create-wiki-button:disabled {
-      background: #ccc;
-      cursor: not-allowed;
-    }
-
-    .instruction-list {
-      margin: 1rem 0;
-      padding-left: 0;
-    }
-
-    .instruction-item {
-      margin-bottom: 1.5rem;
-      padding: 1rem;
-      border-left: 4px solid #007bff;
-      background: #f8f9fa;
-    }
-
-    .instruction-title {
-      font-weight: 600;
-      color: #007bff;
-      margin-bottom: 0.5rem;
-    }
-
-    .instruction-description {
-      color: #555;
-      margin-bottom: 0.5rem;
-    }
-
-    .instruction-link {
-      color: #007bff;
-      text-decoration: none;
-      font-weight: 500;
-    }
-
-    .instruction-link:hover {
-      text-decoration: underline;
-    }
-
-    .join-slack-discussion {
-      padding-top: 6px;
-    }
-
-    .instruction-button {
-      background: #007bff;
-      color: white;
-      border: none;
-      padding: 0.5rem 1rem;
-      border-radius: 4px;
-      cursor: pointer;
-      text-decoration: none;
-    }
-
-    .instruction-button:hover {
-      background: #0056b3;
-    }
-
-    @media (max-width: 768px) {
       .modal-content {
-        width: 95%;
+        background: var(--off-folksonomy-modal-bg, white);
+        padding: 2rem;
+        border-radius: 8px;
+        max-width: 600px;
+        width: 90%;
+        max-height: 80vh;
+        overflow-y: auto;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+      }
+
+      .modal-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1.5rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--off-folksonomy-modal-header-border, #e0e0e0);
+      }
+
+      .modal-title {
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: var(--off-folksonomy-modal-text, #333);
+        margin: 0;
+      }
+
+      .close-button {
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        cursor: pointer;
+        color: var(--off-folksonomy-loading-text, #666);
+        padding: 0.5rem;
+        border-radius: 4px;
+        transition: background-color 0.2s;
+      }
+
+      .close-button:hover {
+        background-color: var(--off-folksonomy-btn-secondary-hover, #f0f0f0);
+      }
+
+      .property-input-section {
+        margin-bottom: 1.5rem;
         padding: 1rem;
+        border: 1px solid var(--off-folksonomy-border, #ddd);
+        border-radius: 4px;
       }
 
       .property-input-container {
-        flex-direction: column;
-        align-items: stretch;
+        align-items: flex-end;
+      }
+
+      .input-group {
+        flex: 1;
+      }
+
+      .input-label {
+        display: block;
+        margin-bottom: 0.5rem;
+        font-weight: 500;
+        color: var(--off-folksonomy-text, inherit);
+      }
+
+      .property-input {
+        width: 100%;
+        padding: 0.5rem;
+        border: 1px solid var(--off-folksonomy-input-border, #ddd);
+        border-radius: 4px;
+        font-size: 1rem;
+        background-color: var(--off-folksonomy-input-bg, rgb(252, 251, 251));
+        color: var(--off-folksonomy-text, #333);
+      }
+
+      .property-input:focus {
+        outline: none;
+        border-color: var(--off-folksonomy-link, #007bff);
       }
 
       .create-wiki-button {
-        margin-top: 0.5rem;
+        margin-top: 4px;
+        background: var(--off-folksonomy-link, #007bff);
+        color: white;
+        border: none;
+        padding: 0.5rem 1rem;
+        border-radius: 4px;
+        cursor: pointer;
       }
-    }
-  `
+
+      .create-wiki-button:hover:not(:disabled) {
+        background: var(--off-folksonomy-link-hover, #0056b3);
+      }
+
+      .create-wiki-button:disabled {
+        background: var(--off-folksonomy-input-border, #ccc);
+        cursor: not-allowed;
+      }
+
+      .instruction-list {
+        margin: 1rem 0;
+        padding-left: 0;
+      }
+
+      .instruction-item {
+        margin-bottom: 1.5rem;
+        padding: 1rem;
+        border-left: 4px solid var(--off-folksonomy-instruction-border, #007bff);
+        background: var(--off-folksonomy-instruction-bg, #f8f9fa);
+      }
+
+      .instruction-title {
+        font-weight: 600;
+        color: var(--off-folksonomy-link, #007bff);
+        margin-bottom: 0.5rem;
+      }
+
+      .instruction-description {
+        color: var(--off-folksonomy-modal-text-secondary, #555);
+        margin-bottom: 0.5rem;
+      }
+
+      .instruction-link {
+        color: var(--off-folksonomy-link, #007bff);
+        text-decoration: none;
+        font-weight: 500;
+      }
+
+      .instruction-link:hover {
+        text-decoration: underline;
+      }
+
+      .join-slack-discussion {
+        padding-top: 6px;
+      }
+
+      .instruction-button {
+        background: var(--off-folksonomy-link, #007bff);
+        color: white;
+        border: none;
+        padding: 0.5rem 1rem;
+        border-radius: 4px;
+        cursor: pointer;
+        text-decoration: none;
+      }
+
+      .instruction-button:hover {
+        background: var(--off-folksonomy-link-hover, #0056b3);
+      }
+
+      @media (max-width: 768px) {
+        .modal-content {
+          width: 95%;
+          padding: 1rem;
+        }
+
+        .property-input-container {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .create-wiki-button {
+          margin-top: 0.5rem;
+        }
+      }
+    `,
+  ]
 
   private handleClose() {
     this.dispatchEvent(

--- a/web-components/src/styles/folksonomy-input.ts
+++ b/web-components/src/styles/folksonomy-input.ts
@@ -4,17 +4,18 @@ export const FOLKSONOMY_INPUT = css`
   input[type="text"] {
     width: 100%;
     padding: 0.5rem;
-    border: 1px solid #ccc;
+    border: 1px solid var(--off-folksonomy-input-border, #ccc);
     border-radius: 5px;
     box-sizing: border-box;
     font-size: 0.9rem;
     height: 2.2rem;
-    background-color: rgb(252, 251, 251);
+    background-color: var(--off-folksonomy-input-bg, rgb(252, 251, 251));
+    color: var(--off-folksonomy-text, #333);
   }
 
   input[type="text"]:focus {
     outline: none;
-    border-color: #007bff;
-    box-shadow: 0 0 3px rgba(0, 123, 255, 0.5);
+    border-color: var(--off-folksonomy-input-focus-border, #007bff);
+    box-shadow: 0 0 3px var(--off-folksonomy-input-focus-shadow, rgba(0, 123, 255, 0.5));
   }
 `

--- a/web-components/src/styles/folksonomy-theme.ts
+++ b/web-components/src/styles/folksonomy-theme.ts
@@ -1,0 +1,76 @@
+import { css } from "lit"
+
+/**
+ * Shared CSS custom properties for theming all Folksonomy Engine components.
+ *
+ * Light-mode defaults are NOT set on :host — they live as var() fallbacks
+ * in each component's styles (e.g. `var(--off-folksonomy-bg, #fff)`).
+ * This allows host pages to override any variable via CSS inheritance:
+ *
+ * @example
+ * ```css
+ * folksonomy-editor {
+ *   --off-folksonomy-bg: #1a1a2e;
+ *   --off-folksonomy-text: #e0e0e0;
+ * }
+ * ```
+ *
+ * Dark-mode overrides are applied automatically via @media (prefers-color-scheme: dark).
+ * Because they ARE set on :host, they take priority over inherited values.
+ * A host page can still force light mode by setting variables directly on the element.
+ */
+export const FOLKSONOMY_THEME = css`
+  @media (prefers-color-scheme: dark) {
+    :host {
+      --off-folksonomy-bg: #1e1e2e;
+      --off-folksonomy-text: #e0e0e0;
+      --off-folksonomy-text-secondary: #ccc;
+      --off-folksonomy-border: #444;
+      --off-folksonomy-shadow: rgba(0, 0, 0, 0.3);
+
+      --off-folksonomy-table-header-bg: #2a2a3a;
+      --off-folksonomy-table-header-bg-alt: #2a2a3a;
+      --off-folksonomy-row-even-bg: #252535;
+      --off-folksonomy-row-even-bg-alt: #252535;
+      --off-folksonomy-row-hover-bg: #2d3748;
+
+      --off-folksonomy-accent: #e8a87c;
+      --off-folksonomy-accent-hover: #d4956a;
+
+      --off-folksonomy-input-bg: #2a2a3a;
+      --off-folksonomy-input-border: #555;
+      --off-folksonomy-input-focus-border: #5b9bd5;
+      --off-folksonomy-input-focus-shadow: rgba(91, 155, 213, 0.5);
+
+      --off-folksonomy-modal-bg: #2a2a3a;
+      --off-folksonomy-modal-text: #e0e0e0;
+      --off-folksonomy-modal-text-secondary: #bbb;
+      --off-folksonomy-modal-header-border: #444;
+
+      --off-folksonomy-danger: #ff6b6b;
+      --off-folksonomy-danger-hover: #ff4757;
+      --off-folksonomy-error-bg: #4a1a1a;
+      --off-folksonomy-error-border: #6b2a2a;
+
+      --off-folksonomy-loading-text: #aaa;
+
+      --off-folksonomy-btn-secondary-bg: #3a3a4a;
+      --off-folksonomy-btn-secondary-hover: #4a4a5a;
+
+      --off-folksonomy-filter-bg: #2a2a3a;
+
+      --off-folksonomy-link: #5b9bd5;
+      --off-folksonomy-link-hover: #4a8bc2;
+
+      --off-folksonomy-instruction-bg: #2a2a3a;
+      --off-folksonomy-instruction-border: #5b9bd5;
+
+      --off-folksonomy-clash-bg: #3d3520;
+      --off-folksonomy-clash-border: #5a4d2a;
+      --off-folksonomy-clash-value: #d4b44a;
+
+      --off-folksonomy-modal-title: #e0e0e0;
+      --off-folksonomy-modal-message: #bbb;
+    }
+  }
+`


### PR DESCRIPTION
### What
Added support for dark mode styling in the Folksonomy Engine webcomponent. This is implemented using **CSS custom properties** rather than an `isDarkMode` Javascript boolean.

This allows the UI to automatically adapt to the user's OS preference (`prefers-color-scheme: dark`) while giving hosting pages complete control over the actual colors by overriding variables from outside the shadow DOM.

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
<img width="1620" height="393" alt="image" src="https://github.com/user-attachments/assets/f256f6e4-db64-46c1-bebc-621080ed53d9" />

### Fixes bug(s)
#244 

### Part of 
- <!-- #1, please use the most granular issue possible -->
