### PR TITLE
feat: support external auth token for Folksonomy editor

### DIFF
--- a/web-components/src/api/folksonomy.ts
+++ b/web-components/src/api/folksonomy.ts
@@ -104,8 +104,11 @@ async function getValidToken(): Promise<string> {
  * @param options
  * @returns {Promise<Response>}
  */
-async function makeAuthenticatedRequest(url: string, options: RequestInit = {}): Promise<Response> {
-  const token = await getValidToken()
+async function makeAuthenticatedRequest(
+  url: string,
+  options: RequestInit & { authToken?: string } = {}
+): Promise<Response> {
+  const token = options.authToken || (await getValidToken())
 
   const requestOptions = {
     ...options,
@@ -118,7 +121,7 @@ async function makeAuthenticatedRequest(url: string, options: RequestInit = {}):
   const response = await fetch(url, requestOptions)
 
   // If auth fails (401/403), try once more with fresh token
-  if (response.status === 401 || response.status === 403) {
+  if ((response.status === 401 || response.status === 403) && !options.authToken) {
     console.error("Auth failed, retrying with fresh token...")
     clearStoredToken()
     const newToken = await getValidToken()
@@ -155,10 +158,12 @@ async function addProductProperty(
   product: string,
   k: string,
   v: string,
-  version: number
+  version: number,
+  options?: { authToken?: string }
 ): Promise<AddProductPropertyResponse> {
   try {
     const response = await makeAuthenticatedRequest(getApiUrl("/product"), {
+      ...options,
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -179,12 +184,14 @@ async function addProductProperty(
 async function deleteProductProperty(
   product: string,
   k: string,
-  version: number
+  version: number,
+  options?: { authToken?: string }
 ): Promise<DeleteProductPropertyResponse> {
   try {
     const response = await makeAuthenticatedRequest(
       getApiUrl(`/product/${product}/${k}?version=${version}`),
       {
+        ...options,
         method: "DELETE",
         headers: {
           "Content-Type": "application/json",
@@ -206,10 +213,12 @@ async function updateProductProperty(
   product: string,
   k: string,
   v: string,
-  version: number
+  version: number,
+  options?: { authToken?: string }
 ): Promise<UpdateProductPropertyResponse> {
   try {
     const response = await makeAuthenticatedRequest(getApiUrl("/product"), {
+      ...options,
       method: "PUT",
       headers: {
         "Content-Type": "application/json",

--- a/web-components/src/components/folksonomy/folksonomy-editor-row.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor-row.ts
@@ -58,6 +58,8 @@ export class FolksonomyEditorRow extends LitElement {
    */
   @property({ type: String, attribute: "product-code" }) productCode = ""
 
+  @property({ type: String, attribute: "auth-token" }) authToken = ""
+
   /**
    * Version number of the product property.
    */
@@ -217,7 +219,8 @@ export class FolksonomyEditorRow extends LitElement {
         this.productCode,
         this.key,
         this.tempValue,
-        this.version
+        this.version,
+        { authToken: this.authToken }
       )
       this.editable = false
 
@@ -254,7 +257,9 @@ export class FolksonomyEditorRow extends LitElement {
     const deleteModal = document.createElement("delete-modal")
     deleteModal.addEventListener("confirm-delete", async () => {
       try {
-        await folksonomyApi.deleteProductProperty(this.productCode, this.key, this.version)
+        await folksonomyApi.deleteProductProperty(this.productCode, this.key, this.version, {
+          authToken: this.authToken,
+        })
         this.dispatchEvent(
           new CustomEvent("delete-row", {
             detail: { key: this.key },
@@ -282,7 +287,8 @@ export class FolksonomyEditorRow extends LitElement {
           this.productCode,
           this.keyInput,
           this.valueInput,
-          this.version
+          this.version,
+          { authToken: this.authToken }
         )
         this.dispatchEvent(
           new CustomEvent("add-row", {

--- a/web-components/src/components/folksonomy/folksonomy-editor.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor.ts
@@ -19,6 +19,9 @@ export class FolksonomyEditor extends LitElement {
   @property({ type: String, attribute: "product-code" })
   productCode = ""
 
+  @property({ type: String, attribute: "auth-token" })
+  authToken = ""
+
   /**
    * The type of page being displayed (e.g., "view", "edit")
    * @type {string}
@@ -277,6 +280,7 @@ export class FolksonomyEditor extends LitElement {
                 version=${item.version}
                 row-number=${index + 1}
                 page-type=${this.pageType}
+                auth-token=${this.authToken}
               ></folksonomy-editor-row>`
           )}
           ${this.pageType == "edit"
@@ -284,6 +288,7 @@ export class FolksonomyEditor extends LitElement {
                 product-code=${this.productCode}
                 page-type=${this.pageType}
                 row-number=${this.properties.length + 1}
+                auth-token=${this.authToken}
                 empty
               ></folksonomy-editor-row>`
             : null}


### PR DESCRIPTION
### What
Implemented the external token injection :
- Added an auth-token property to the `<folksonomy-editor>` and `<folksonomy-editor-row>` components.
- Updated the internal API layer (`makeAuthenticatedRequest`) to prioritize this external token if provided.
- Bypassed the default `auth_by_cookie` flow when an external token is present to ensure compatibility with host applications like Explorer auth states.

### Part of 
- https://github.com/openfoodfacts/openfoodfacts-explorer/issues/1145
