### PR TITLE
fix: Guard global window access in dark-mode-listener for SSR (#469)

### DIFF
--- a/web-components/src/utils/dark-mode-listener.ts
+++ b/web-components/src/utils/dark-mode-listener.ts
@@ -4,14 +4,19 @@
 export type DarkModeCallback = (isDark: boolean) => void
 
 class DarkModeListener {
-  private isDark: boolean
+  private isDark: boolean = false
   private listeners: Set<DarkModeCallback> = new Set()
-  private mq: MediaQueryList
+  private mq: MediaQueryList | null = null
 
   constructor() {
-    this.mq = window.matchMedia("(prefers-color-scheme: dark)")
-    this.isDark = this.mq.matches
-    this.mq.addEventListener("change", this.handleChange)
+    // Guard against SSR environments (e.g. Node.js / SvelteKit / Nuxt)
+    // where `window` is not defined. In those cases we fall back to
+    // `isDark = false` and skip MediaQuery initialisation entirely.
+    if (typeof window !== "undefined") {
+      this.mq = window.matchMedia("(prefers-color-scheme: dark)")
+      this.isDark = this.mq.matches
+      this.mq.addEventListener("change", this.handleChange)
+    }
   }
 
   private handleChange = (e: MediaQueryListEvent) => {


### PR DESCRIPTION
Fixes #469

**What this PR does:**
This Pull Request wraps the initialization of the `MediaQueryList` inside `dark-mode-listener.ts` with a `typeof window !== "undefined"` check. 

**Why it is needed:**
Because `darkModeListener` is created as an instance and exported immediately at the module level, this code executes as soon as the file is imported. Doing this in a Node.js SSR environment (such as when integrating these web components into SvelteKit or Nuxt for the Explorer frontend) throws a fatal `ReferenceError: window is not defined`. This PR safely guards the dom APIs to ensure the package doesn't crash SSR execution.