### PR TITLE
fix(getImageUrl): strip trailing slash from assetsImagesPath to prevent double slashes

### DIFF
--- a/web-components/src/signals/app.test.ts
+++ b/web-components/src/signals/app.test.ts
@@ -95,14 +95,27 @@ describe("App Signals", () => {
       expect(getImageUrl(fileName)).toBe("/assets/image.png")
     })
 
-    it("should handle assets path with trailing slash", () => {
+    it("should not produce double slash when assets path has trailing slash", () => {
+      // Regression test for https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/473
       assetsImagesPath.set("/assets/")
       const fileName = "image.png"
-      expect(getImageUrl(fileName)).toBe("/assets//image.png") // Double slash - might be a bug in implementation
+      expect(getImageUrl(fileName)).toBe("/assets/image.png")
+    })
+
+    it("should strip multiple trailing slashes", () => {
+      assetsImagesPath.set("/assets///")
+      const fileName = "logo.png"
+      expect(getImageUrl(fileName)).toBe("/assets/logo.png")
     })
 
     it("should work with CDN URLs", () => {
       assetsImagesPath.set("https://cdn.example.com/assets")
+      const fileName = "logo.svg"
+      expect(getImageUrl(fileName)).toBe("https://cdn.example.com/assets/logo.svg")
+    })
+
+    it("should work with CDN URLs that have trailing slash", () => {
+      assetsImagesPath.set("https://cdn.example.com/assets/")
       const fileName = "logo.svg"
       expect(getImageUrl(fileName)).toBe("https://cdn.example.com/assets/logo.svg")
     })

--- a/web-components/src/signals/app.ts
+++ b/web-components/src/signals/app.ts
@@ -8,7 +8,7 @@ import {
 export const assetsImagesPath = signal(DEFAULT_ASSETS_IMAGES_PATH)
 
 export const getImageUrl = (fileName: string) => {
-  return `${assetsImagesPath.get()}/${fileName}`
+  return `${assetsImagesPath.get().replace(/\/+$/, "")}/${fileName}`
 }
 
 export const countryCode = signal(DEFAULT_COUNTRY_CODE)


### PR DESCRIPTION
### Description

`getImageUrl()` in `web-components/src/signals/app.ts` produces URLs with double slashes when `assetsImagesPath` ends with a trailing `/` (e.g. set by an integrating app via `assetsImagesPath.set("/assets/")`).

```ts
// Before fix:
assetsImagesPath.set("/assets/")
getImageUrl("logo.png") // → "/assets//logo.png" ❌

// After fix:
getImageUrl("logo.png") // → "/assets/logo.png" ✅
```

The bug was already acknowledged in `app.test.ts` with the comment `"// Double slash - might be a bug in implementation"`, but the test was accepting the broken output.

**Fix in `app.ts`:**
```diff
-  return `${assetsImagesPath.get()}/${fileName}`
+  return `${assetsImagesPath.get().replace(/\/+$/, "")}/${fileName}`
```

**Fix in `app.test.ts`:**
- Replaced the broken test (which expected `/assets//image.png`) with a proper **regression test** that asserts `/assets/image.png`
- Added a test for **multiple trailing slashes** (`/assets///`)
- Added a test for **CDN URLs with trailing slashes**

### Screenshot or video

_No visual changes — logic fix._

### Related issue(s) and discussion

- Fixes: #473

---

### Checklist: Author Self-Review

- [x] I have performed a self-review of my own code (including running it).
- [x] I understand the changes I'm proposing and why they are needed.
- [x] My changes generate no new warnings or errors (linting, console).
- [ ] I have made corresponding changes to the documentation (if applicable).

## Large Language Models usage disclosure

- [ ] <!-- ⚠️ If you used an LLM, please replace [ ] by [x], and add which LLM you used (name, version) and how (agentic, autocomplete…) --> Generic LLM v0.0.0
