### PR TITLE
fix: Markdown link syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A set of web components for Open Food Facts to help build edition interfaces
 ## 📆 Weekly meetings
 
 - We e-meet Wednesdays · 11:00 – 11:25am - Time zone: Europe/Paris
-- ![Google Meet](https://meet.google.com/uep-fhvf-gto) Video call link: https://meet.google.com/uep-fhvf-gto
+- [Google Meet](https://meet.google.com/uep-fhvf-gto) Video call link: https://meet.google.com/uep-fhvf-gto
 - Join by phone: https://tel.meet/uep-fhvf-gto?pin=8160344286211
 - Add the Event to your Calendar by [adding the Open Food Facts community calendar to your calendar](https://wiki.openfoodfacts.org/Events)
 - [Weekly Agenda](https://docs.google.com/document/d/1BGHfvrgx5eFIGjK8aTNPK2QwAggRp4oohGuYG9lNX8g/edit?tab=t.0): please add the Agenda items as early as you can. Make sure to check the Agenda items in advance of the meeting, so that we have the most informed discussions possible, leading to argumented decisions.


### PR DESCRIPTION
### What
- Replaced incorrect image syntax with proper link syntax

### Result
- Link now renders correctly in GitHub preview

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

** Before **
<img width="564" height="124" alt="Screenshot 2026-03-26 at 15 45 14" src="https://github.com/user-attachments/assets/e080c0ef-a457-4d76-9042-49e019c6c8a6" />

</br>
** After **
<img width="582" height="117" alt="Screenshot 2026-03-26 at 15 46 11" src="https://github.com/user-attachments/assets/055699f0-ddc5-4fb8-9c80-f4eed4978af2" />



### Fixes bug(s)
- #481


### Part of 
- <!-- #1, please use the most granular issue possible -->
