### PR TITLE
feat(folksonomy): add view-only mode for unauthenticated users

### DIFF
--- a/web-components/src/components/folksonomy/folksonomy-editor.stories.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor.stories.ts
@@ -12,3 +12,51 @@ type Story = StoryObj
 export const Basic: Story = {
   args: {},
 }
+
+export const EditMode: Story = {
+  args: {
+    "page-type": "edit",
+    "product-code": "3274080005003",
+  },
+  render: (args) => {
+    const element = document.createElement("folksonomy-editor") as any
+    element.fetchAndLogFolksonomyKeys = async () => {} // Prevent real network fetch in Storybook
+    element.setAttribute("page-type", args["page-type"] as string)
+    element.setAttribute("product-code", args["product-code"] as string)
+
+    // Set mock properties synchronously right away (no setTimeout)
+    const component = element as any
+    component.properties = [
+      { key: "Origin", value: "France", version: 1 },
+      { key: "Producer", value: "Example Corp", version: 1 },
+      { key: "Certification", value: "Organic", version: 2 },
+    ]
+
+    return element
+  },
+}
+
+export const ViewOnlyMode: Story = {
+  args: {
+    "page-type": "edit",
+    "view-only": true,
+    "product-code": "3274080005003",
+  },
+  render: (args) => {
+    const element = document.createElement("folksonomy-editor") as any
+    element.fetchAndLogFolksonomyKeys = async () => {} // Prevent real network fetch in Storybook
+    element.setAttribute("page-type", args["page-type"] as string)
+    element.setAttribute("product-code", args["product-code"] as string)
+    element.setAttribute("view-only", "")
+
+    // Set mock properties synchronously right away (no setTimeout)
+    const component = element as any
+    component.properties = [
+      { key: "Origin", value: "France", version: 1 },
+      { key: "Producer", value: "Example Corp", version: 1 },
+      { key: "Certification", value: "Organic", version: 2 },
+    ]
+
+    return element
+  },
+}

--- a/web-components/src/components/folksonomy/folksonomy-editor.ts
+++ b/web-components/src/components/folksonomy/folksonomy-editor.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from "lit"
+﻿import { LitElement, html, css } from "lit"
 import { customElement, property, state } from "lit/decorators.js"
 import { localized, msg } from "@lit/localize"
 import "./folksonomy-editor-row"
@@ -28,11 +28,25 @@ export class FolksonomyEditor extends LitElement {
   pageType = "view"
 
   /**
+   * Disables editing and adding properties for non-logged-in users.
+   * @type {boolean}
+   */
+  @property({ type: Boolean, attribute: "view-only" })
+  viewOnly = false
+
+  /**
    * The base URL for properties listing (e.g., "https://world.openfoodfacts.org/properties")
    * @type {string}
    */
   @property({ type: String, attribute: "properties-base-url" })
   propertiesBaseUrl = "/properties"
+
+  /**
+   * The URL for the login page
+   * @type {string}
+   */
+  @property({ type: String, attribute: "login-url" })
+  loginUrl = "/cgi/login.pl"
 
   /**
    * The URL for properties documentation (e.g., "https://wiki.openfoodfacts.org/Folksonomy/Property")
@@ -54,6 +68,10 @@ export class FolksonomyEditor extends LitElement {
       :host {
         font-family: Arial, sans-serif;
         color: var(--off-folksonomy-text, #333);
+      }
+      .login-message {
+        margin-top: 1rem;
+        font-style: italic;
       }
       .feus {
         margin-bottom: 1rem;
@@ -201,6 +219,7 @@ export class FolksonomyEditor extends LitElement {
 
   override connectedCallback() {
     super.connectedCallback()
+
     this.fetchAndLogFolksonomyKeys()
 
     this.addEventListener("add-row", this.handleRowAdd as EventListener)
@@ -270,7 +289,7 @@ export class FolksonomyEditor extends LitElement {
             >
               <span class="sort-header"> ${msg("Value")} ${this.renderSortIcon("value")} </span>
             </th>
-            ${this.pageType == "edit" ? html`<th>${msg("Actions")}</th>` : null}
+            ${this.pageType == "edit" && !this.viewOnly ? html`<th>${msg("Actions")}</th>` : null}
           </tr>
           ${this.properties.map(
             (item, index) =>
@@ -280,10 +299,10 @@ export class FolksonomyEditor extends LitElement {
                 value=${item.value}
                 version=${item.version}
                 row-number=${index + 1}
-                page-type=${this.pageType}
+                page-type=${this.viewOnly ? "view" : this.pageType}
               ></folksonomy-editor-row>`
           )}
-          ${this.pageType == "edit"
+          ${this.pageType == "edit" && !this.viewOnly
             ? html`<folksonomy-editor-row
                 product-code=${this.productCode}
                 page-type=${this.pageType}
@@ -292,6 +311,11 @@ export class FolksonomyEditor extends LitElement {
               ></folksonomy-editor-row>`
             : null}
         </table>
+        ${this.viewOnly
+          ? html`<p class="login-message">
+              ${msg(html`Please <a href="${this.loginUrl}">log in</a> to edit or add properties.`)}
+            </p>`
+          : null}
       </form>
     `
   }


### PR DESCRIPTION
Resolves #269

## Description
Hi team! This PR introduces the requested 'view-only' mode to the '<folksonomy-editor>' component. The goal here is to safely display folksonomy properties to non-logged-in users while cleanly hiding all the editing controls, action buttons, and empty input fields.

## What's Changed
- **New State**: Added a 'view-only' boolean property to the main '<folksonomy-editor>' component.

- **Header & Inputs**: The 'Actions' column header and the trailing empty input row are now conditionally hidden when 'view-only' is active.

- **Row State Propagation**: Child '<folksonomy-editor-row>' components now receive a computed 'page-type' (forced to 'view'), ensuring they hide their internal edit/delete toggles.

- **Login Prompt**: Added a friendly fallback message at the bottom of the component prompting users to log in if they want to edit or add properties.

- **Storybook Testing**: Created 'ViewOnlyMode' and 'EditMode' mock stories in 'folksonomy.stories.ts' for easy visual validation and comparison of both modes without requiring Open Food Facts API endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added view-only mode to the folksonomy editor — hides editing controls and extra add-row, forces rows into view-only rendering, and shows an italicized login prompt with a configurable login URL.

* **Tests**
  * Added Storybook stories for Edit and View-only modes to support visual testing and review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->