### PR TITLE
fix: resolve localization bug using placeholders (#467)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "openfoodfacts-webcomponents",
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "jest": "^29.7.0",
@@ -56,7 +55,6 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1278,7 +1276,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2179,7 +2176,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "openfoodfacts-webcomponents",
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "jest": "^29.7.0",
@@ -55,6 +56,7 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1276,6 +1278,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2176,6 +2179,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",

--- a/web-components/src/components/mobile-badges/mobile-badges.ts
+++ b/web-components/src/components/mobile-badges/mobile-badges.ts
@@ -429,9 +429,9 @@ export class MobileBadges extends LitElement {
         <div id="footer_scan" style="display:block">
           <div id="footer_install_the_app">${msg("Install the app!")}</div>
           
-         ${msg(str`Scan your ${'everyday'} ${'foods'}`, {
-      everyday: html`<span class="everyday">everyday</span>`,
-      foods: html`<span class="foods">foods</span>`
+    ${msg(str`Scan your ${'everyday'} ${'foods'}`, {
+      everyday: html`<span class="everyday">${msg('everyday')}</span>`,
+      foods: html`<span class="foods">${msg('foods')}</span>`
     })}
         </div>
       </div>

--- a/web-components/src/components/mobile-badges/mobile-badges.ts
+++ b/web-components/src/components/mobile-badges/mobile-badges.ts
@@ -428,11 +428,13 @@ export class MobileBadges extends LitElement {
         />
         <div id="footer_scan" style="display:block">
           <div id="footer_install_the_app">${msg("Install the app!")}</div>
-          
-    ${msg(str`Scan your ${'everyday'} ${'foods'}`, {
-      everyday: html`<span class="everyday">${msg('everyday')}</span>`,
-      foods: html`<span class="foods">${msg('foods')}</span>`
-    })}
+            ${msg(
+      str`Scan your ${"everyday"} ${"foods"}`,
+      {
+        everyday: html`<span class="everyday">${msg(str`everyday`)}</span>`,
+        foods: html`<span class="foods">${msg(str`foods`)}</span>`,
+      }
+    )}
         </div>
       </div>
     `

--- a/web-components/src/components/mobile-badges/mobile-badges.ts
+++ b/web-components/src/components/mobile-badges/mobile-badges.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css, nothing } from "lit"
 import { customElement, state, property } from "lit/decorators.js"
-import { localized, msg } from "@lit/localize"
+import { localized, msg, str } from "@lit/localize"
 import { getImageUrl, languageCode } from "../../signals/app"
 import { classMap } from "lit/directives/class-map.js"
 import { darkModeListener } from "../../utils/dark-mode-listener"
@@ -428,10 +428,11 @@ export class MobileBadges extends LitElement {
         />
         <div id="footer_scan" style="display:block">
           <div id="footer_install_the_app">${msg("Install the app!")}</div>
-          <!-- TODO find fix to add text between span for translations ex for fr : "Scannez vos <span class="foods">aliments</span> de votre <span class="everyday">quotidien</span>" -->
-          ${msg(
-            html`Scan your <span class="everyday">everyday</span> <span class="foods">foods</span>`
-          )}
+          
+         ${msg(str`Scan your ${'everyday'} ${'foods'}`, {
+      everyday: html`<span class="everyday">everyday</span>`,
+      foods: html`<span class="foods">foods</span>`
+    })}
         </div>
       </div>
     `
@@ -448,8 +449,8 @@ export class MobileBadges extends LitElement {
       ? html`
           <div class="badge-container ">
             ${filteredBadges.map((badge) =>
-              this.generateBadgeLink(badge.href, badge.src, badge.alt, badge.id, badge.errorHandler)
-            )}
+        this.generateBadgeLink(badge.href, badge.src, badge.alt, badge.id, badge.errorHandler)
+      )}
           </div>
         `
       : ""}`


### PR DESCRIPTION
### What
- Fixed localization issue in mobile-badges component where msg(html...) prevented translation extraction
- Replaced msg(html...) with msg(str...) using placeholders
- Ensured styled words ("everyday", "foods") remain visually intact while allowing proper translations

### Screenshot
- No visual changes; fix is related to localization only

### Fixes bug(s)
- Closes #467

### Part of 
-- #467


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved localization handling in mobile badges component by restructuring how translated text is constructed and organized for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->