### PR TITLE
feat: adds country filtering and pagination support to the nutrient extraction web component, enabling Hunger Games to filter nutrition insights by country

### DIFF
--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -124,6 +124,7 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
   private readonly pageSize: number = 10
 
   private fetchMoreInsightsPromise?: Promise<void>
+  private fetchSessionToken: number = 0
 
   get currentInsightId() {
     return this.insightsIds[this.currentInsightIndex]
@@ -156,12 +157,15 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
    */
   private _insightsTask = new Task(this, {
     task: async ([productCode], {}) => {
+      this.fetchSessionToken++
+      const sessionToken = this.fetchSessionToken
       this.emitNutrientEvent(EventState.LOADING)
       this.currentInsightIndex = 0
       this.currentPage = 1
       this.totalInsightsCount = 0
       this.insightsIds = []
       this.annotatedIds = new Set()
+      this.fetchMoreInsightsPromise = undefined
 
       // Keep country filtering optional; do not send lc as it can hide valid insights.
       const params: any = {
@@ -178,6 +182,9 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
         fetchNutrientsOrderByCountryCode(this.countryCode || this._countryCode),
       ])
 
+      // If a new session started, abort writing state
+      if (sessionToken !== this.fetchSessionToken) return
+
       const insights = insightsResponse.insights
       this.totalInsightsCount = insightsResponse.count ?? insights.length
 
@@ -193,6 +200,7 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
   })
 
   private async fetchNextInsightsPage() {
+    const sessionToken = this.fetchSessionToken
     if (this.fetchMoreInsightsPromise) {
       return this.fetchMoreInsightsPromise
     }
@@ -212,8 +220,12 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
         }
 
         const response = await fetchNutrientInsights(this.productCode, params)
+        // If a new session started, abort writing state
+        if (sessionToken !== this.fetchSessionToken) return
         this.totalInsightsCount = response.count ?? this.totalInsightsCount
-        const existingIds = new Set(this.insightsIds)
+
+        // Also exclude already-annotated IDs so they can never re-enter the buffer
+        const existingIds = new Set([...this.insightsIds, ...this.annotatedIds])
         const nextIds = response.insights
           .map((insight) => insight.id)
           .filter((id) => !existingIds.has(id))
@@ -248,6 +260,10 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
 
     this.currentInsightIndex = index
     const insight = this.currentInsight
+    if (!insight) {
+      this.emitNutrientEvent(EventState.NO_DATA)
+      return
+    }
     await this.getProductNutriments(insight.barcode)
   }
 

--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -113,6 +113,15 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
   @state()
   private nutrimentsData?: NutrimentsProductType
 
+  @state()
+  private totalInsightsCount: number = 0
+
+  private currentPage: number = 1
+
+  private readonly pageSize: number = 10
+
+  private fetchMoreInsightsPromise?: Promise<void>
+
   get currentInsightId() {
     return this.insightsIds[this.currentInsightIndex]
   }
@@ -145,13 +154,28 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
   private _insightsTask = new Task(this, {
     task: async ([productCode], {}) => {
       this.emitNutrientEvent(EventState.LOADING)
-      const [insights] = await Promise.all([
-        fetchNutrientInsights(productCode, {
-          lc: this._languageCodes,
-        }),
+      this.currentInsightIndex = 0
+      this.currentPage = 1
+      this.totalInsightsCount = 0
+      this.insightsIds = []
+
+      // Keep country filtering optional; do not send lc as it can hide valid insights.
+      const params: any = {
+        count: this.pageSize,
+        page: this.currentPage,
+      }
+      if (this.countryCode) {
+        params.countries = this.countryCode
+      }
+
+      const [insightsResponse] = await Promise.all([
+        fetchNutrientInsights(productCode, params),
         fetchNutrientsTaxonomies(),
-        fetchNutrientsOrderByCountryCode(this._countryCode),
+        fetchNutrientsOrderByCountryCode(this.countryCode || this._countryCode),
       ])
+
+      const insights = insightsResponse.insights
+      this.totalInsightsCount = insightsResponse.count ?? insights.length
 
       this.insightsIds = insights.map((insight) => insight.id)
       if (!this.insightsIds.length) {
@@ -164,11 +188,60 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     args: () => [this.productCode, this.countryCode, ...this._languageCodes],
   })
 
+  private async fetchNextInsightsPage() {
+    if (this.fetchMoreInsightsPromise) {
+      return this.fetchMoreInsightsPromise
+    }
+    if (this.insightsIds.length >= this.totalInsightsCount) {
+      return
+    }
+
+    this.fetchMoreInsightsPromise = (async () => {
+      try {
+        const nextPage = this.currentPage + 1
+        const params: any = {
+          count: this.pageSize,
+          page: nextPage,
+        }
+        if (this.countryCode) {
+          params.countries = this.countryCode
+        }
+
+        const response = await fetchNutrientInsights(this.productCode, params)
+        this.totalInsightsCount = response.count ?? this.totalInsightsCount
+        const existingIds = new Set(this.insightsIds)
+        const nextIds = response.insights
+          .map((insight) => insight.id)
+          .filter((id) => !existingIds.has(id))
+
+        if (nextIds.length > 0) {
+          this.insightsIds = [...this.insightsIds, ...nextIds]
+        }
+
+        this.currentPage = nextPage
+      } finally {
+        this.fetchMoreInsightsPromise = undefined
+      }
+    })()
+
+    return this.fetchMoreInsightsPromise
+  }
+
   async loadInsight(index: number) {
+    if (index >= this.insightsIds.length && this.insightsIds.length < this.totalInsightsCount) {
+      await this.fetchNextInsightsPage()
+    }
+
     if (index >= this.insightsIds.length) {
       this.emitNutrientEvent(EventState.FINISHED)
       return
     }
+
+    const remainingBuffered = this.insightsIds.length - index
+    if (remainingBuffered <= 5 && this.insightsIds.length < this.totalInsightsCount) {
+      void this.fetchNextInsightsPage()
+    }
+
     this.currentInsightIndex = index
     const insight = this.currentInsight
     await this.getProductNutriments(insight.barcode)
@@ -218,7 +291,17 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
   async afterInsightAnnotation() {
     await this.hideLoading()
     this.emitNutrientEvent(EventState.ANNOTATED)
-    this.loadInsight(this.currentInsightIndex + 1)
+
+    // Remove the annotated item from the list (like Questions does)
+    const annotatedId = this.currentInsightId
+    this.insightsIds = this.insightsIds.filter((id) => id !== annotatedId)
+
+    // Check if we need to fetch more (like Questions: if count > length && length <= 5)
+    if (this.totalInsightsCount > this.insightsIds.length && this.insightsIds.length <= 5) {
+      void this.fetchNextInsightsPage()
+    }
+
+    this.loadInsight(this.currentInsightIndex)
   }
 
   /**
@@ -249,9 +332,13 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     await this.afterInsightAnnotation()
   }
   renderHeader(insight: NutrientsInsight) {
+    const total = this.totalInsightsCount || this.insightsIds.length
+    const remainingProducts = Math.max(total - this.currentInsightIndex, 0)
+
     return html`
       <div>
         <h2>${msg("Help us correct the nutritional information")}</h2>
+        <p>${msg("Remaining products")}: ${remainingProducts}</p>
         ${this.renderProductLink(insight.barcode)}
       </div>
     `
@@ -263,7 +350,11 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
       complete: () => {
         const insight = this.currentInsight
         if (!insight) {
-          return html`<slot name="no-insight"></slot>`
+          return html`
+            <p>${msg("No more products available for this filter.")}</p>
+            <p>${msg("Remaining products")}: 0</p>
+            <slot name="no-insight"></slot>
+          `
         }
         return html`
           <div class="nutrients" part="nutrients">

--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -104,7 +104,6 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
   @property({ type: String, attribute: "product-code", reflect: true })
   productCode?: string = undefined
 
-
   @state()
   insightsIds: string[] = []
 

--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -244,8 +244,12 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
   }
 
   async loadInsight(index: number) {
-    if (index >= this.insightsIds.length && this.insightsIds.length < this.totalInsightsCount) {
+    while (index >= this.insightsIds.length && this.insightsIds.length < this.totalInsightsCount) {
+      const lengthBefore = this.insightsIds.length
+      const pageBefore = this.currentPage
       await this.fetchNextInsightsPage()
+      // No progress (e.g. page returned only dupes and no longer advanced) → stop to avoid an infinite loop.
+      if (this.insightsIds.length === lengthBefore && this.currentPage === pageBefore) break
     }
 
     if (index >= this.insightsIds.length) {
@@ -314,8 +318,10 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
 
     // Remove the annotated item from the list (like Questions does)
     const annotatedId = this.currentInsightId
-    this.insightsIds = this.insightsIds.filter((id) => id !== annotatedId)
-    this.annotatedIds.add(annotatedId)
+    if (annotatedId) {
+      this.insightsIds = this.insightsIds.filter((id) => id !== annotatedId)
+      this.annotatedIds = new Set(this.annotatedIds).add(annotatedId)
+    }
 
     // Check if we need to fetch more (like Questions: if count > length && length <= 5)
     if (this.totalInsightsCount > this.insightsIds.length && this.insightsIds.length <= 5) {

--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -104,8 +104,12 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
   @property({ type: String, attribute: "product-code", reflect: true })
   productCode?: string = undefined
 
+
   @state()
   insightsIds: string[] = []
+
+  @state()
+  annotatedIds: Set<string> = new Set()
 
   @state()
   currentInsightIndex: number = 0
@@ -158,6 +162,7 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
       this.currentPage = 1
       this.totalInsightsCount = 0
       this.insightsIds = []
+      this.annotatedIds = new Set()
 
       // Keep country filtering optional; do not send lc as it can hide valid insights.
       const params: any = {
@@ -295,13 +300,14 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     // Remove the annotated item from the list (like Questions does)
     const annotatedId = this.currentInsightId
     this.insightsIds = this.insightsIds.filter((id) => id !== annotatedId)
+    this.annotatedIds.add(annotatedId)
 
     // Check if we need to fetch more (like Questions: if count > length && length <= 5)
     if (this.totalInsightsCount > this.insightsIds.length && this.insightsIds.length <= 5) {
       void this.fetchNextInsightsPage()
     }
 
-    this.loadInsight(this.currentInsightIndex)
+    await this.loadInsight(this.currentInsightIndex)
   }
 
   /**
@@ -332,9 +338,7 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
     await this.afterInsightAnnotation()
   }
   renderHeader(insight: NutrientsInsight) {
-    const total = this.totalInsightsCount || this.insightsIds.length
-    const remainingProducts = Math.max(total - this.currentInsightIndex, 0)
-
+    const remainingProducts = Math.max(this.totalInsightsCount - this.annotatedIds.size, 0)
     return html`
       <div>
         <h2>${msg("Help us correct the nutritional information")}</h2>

--- a/web-components/src/signals/nutrient-extraction.test.ts
+++ b/web-components/src/signals/nutrient-extraction.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import robotoff from "../api/robotoff"
+import {
+  annotateNutrientsWithData,
+  annotateNutrientWithoutData,
+  fetchNutrientInsights,
+  insightById,
+  insightIdByProductCode,
+} from "./nutrient-extraction"
+import { AnnotationAnswer, InsightAnnotationSize, InsightType } from "../types/robotoff"
+
+vi.mock("../api/robotoff", () => ({
+  default: {
+    insights: vi.fn(),
+    annotateNutrients: vi.fn(),
+  },
+}))
+
+describe("Nutrient extraction signals", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    insightById.set({})
+    insightIdByProductCode.set({})
+  })
+
+  it("returns full insights response and stores insight mappings", async () => {
+    const response = {
+      count: 2,
+      status: "success",
+      insights: [
+        { id: "insight-1", barcode: "1111111111111" },
+        { id: "insight-2", barcode: "2222222222222" },
+      ],
+    }
+
+    vi.mocked(robotoff.insights).mockResolvedValue(response as any)
+
+    const result = await fetchNutrientInsights("1111111111111", {
+      count: 10,
+      page: 2,
+      countries: "fr",
+    })
+
+    expect(robotoff.insights).toHaveBeenCalledWith({
+      count: 10,
+      page: 2,
+      countries: "fr",
+      barcode: "1111111111111",
+      insight_types: InsightType.nutrient_extraction,
+      annotated: false,
+    })
+    expect(result).toEqual(response)
+    expect(insightById.getItem("insight-1")).toEqual(response.insights[0])
+    expect(insightById.getItem("insight-2")).toEqual(response.insights[1])
+    expect(insightIdByProductCode.getItem("1111111111111")).toBe("insight-1")
+    expect(insightIdByProductCode.getItem("2222222222222")).toBe("insight-2")
+  })
+
+  it("initializes product mapping to null when no insight is returned", async () => {
+    vi.mocked(robotoff.insights).mockResolvedValue({
+      count: 0,
+      status: "success",
+      insights: [],
+    } as any)
+
+    await fetchNutrientInsights("3333333333333")
+
+    expect(insightIdByProductCode.getItem("3333333333333")).toBeNull()
+  })
+
+  it("annotateNutrientsWithData sends cleaned payload", async () => {
+    vi.mocked(robotoff.annotateNutrients).mockResolvedValue({ status: "saved" } as any)
+
+    await annotateNutrientsWithData({
+      insightId: "insight-42",
+      type: InsightAnnotationSize.CENTGRAMS,
+      data: {
+        proteins: { value: "10", unit: "g" },
+        serving_size: { value: "25", unit: null },
+      },
+    })
+
+    expect(robotoff.annotateNutrients).toHaveBeenCalledWith(
+      "insight-42",
+      AnnotationAnswer.ACCEPT_AND_ADD_DATA,
+      {
+        serving_size: "25",
+        nutrition_data_per: InsightAnnotationSize.CENTGRAMS,
+        nutrients: {
+          proteins: { value: "10", unit: "g" },
+        },
+      }
+    )
+  })
+
+  it("annotateNutrientWithoutData forwards insight id and annotation", async () => {
+    vi.mocked(robotoff.annotateNutrients).mockResolvedValue({ status: "saved" } as any)
+
+    await annotateNutrientWithoutData("insight-99", AnnotationAnswer.SKIP)
+
+    expect(robotoff.annotateNutrients).toHaveBeenCalledWith("insight-99", AnnotationAnswer.SKIP)
+  })
+})

--- a/web-components/src/signals/nutrient-extraction.ts
+++ b/web-components/src/signals/nutrient-extraction.ts
@@ -4,6 +4,7 @@ import {
   type NutrientsInsight,
   type InsightAnnotationAnswer,
   type InsightsRequestParams,
+  type InsightsResponse,
   type NutrientsAnnotationData,
   InsightType,
   AnnotationAnswer,
@@ -42,7 +43,7 @@ export const insight = (productCode: string) => {
 export const fetchNutrientInsights = async (
   productCode?: string,
   requestParams: InsightsRequestParams = {}
-): Promise<NutrientsInsight[]> => {
+): Promise<InsightsResponse<NutrientsInsight>> => {
   const params: InsightsRequestParams = {
     ...requestParams,
     insight_types: InsightType.nutrient_extraction,
@@ -52,6 +53,7 @@ export const fetchNutrientInsights = async (
     params["barcode"] = productCode
     insightIdByProductCode.setItem(productCode, null)
   }
+
   const response = await robotoff.insights<NutrientsInsight>(params)
 
   response.insights.forEach((insight) => {
@@ -59,7 +61,7 @@ export const fetchNutrientInsights = async (
     insightIdByProductCode.setItem(insight.barcode, insight.id)
   })
 
-  return response.insights
+  return response
 }
 
 /**

--- a/web-components/xliff/en.xlf
+++ b/web-components/xliff/en.xlf
@@ -718,6 +718,12 @@
         <source>No Score Available</source>
         <target state="needs-translation">No Score Available</target>
       </trans-unit>
+      <trans-unit id="sa4efa3283e995ce1">
+        <source>Remaining products</source>
+      </trans-unit>
+      <trans-unit id="s2186dc7d7ece737f">
+        <source>No more products available for this filter.</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/fr.xlf
+++ b/web-components/xliff/fr.xlf
@@ -716,6 +716,14 @@
         <source>No Score Available</source>
         <target state="needs-review-translation" state-qualifier="leveraged-mt">Aucune partition disponible</target>
       </trans-unit>
+      <trans-unit id="sa4efa3283e995ce1">
+        <source>Remaining products</source>
+        <target>Produits restants</target>
+      </trans-unit>
+      <trans-unit id="s2186dc7d7ece737f">
+        <source>No more products available for this filter.</source>
+        <target>Aucun produit disponible pour ce filtre.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
### What
This PR adds country filtering and pagination support to the nutrient extraction web component, enabling Hunger Games to filter nutrition insights by country while maintaining smooth UX with prefetch-ahead loading.

**Changes:**
- **robotoff-nutrient-extraction.ts**: Added country-codes attribute support, paginated insight loading with prefetch logic, post-annotation list management, and UI text for remaining/empty states.
- **nutrient-extraction.ts**: Changed `fetchNutrientInsights` to return full `InsightsResponse` (count + insights array) enabling pagination metadata access while keeping insight ID maps updated.
- **nutrient-extraction.test.ts**: Added tests for response contract, mapping behavior, and annotation payload handling.
- **en.xlf / fr.xlf**: Added translations for "Remaining products" and "No more products available for this filter."

**Context:**
Supports new country filtering feature in Hunger Games nutrition page. Pagination ensures responsive UX when filtering reduces available insights, and remaining count provides progress feedback.


**Used of agent**
Claude was used as an agent in VS Code.

Hunger Games ran locally using local version of webcomponents. See screenshot below.

### Screenshot
<img width="1212" height="706" alt="Screenshot_20260412_001846" src="https://github.com/user-attachments/assets/b40cdd6d-5a59-4df7-b9e3-182a0d37bc70" />
<img width="1202" height="886" alt="Screenshot_20260412_001818" src="https://github.com/user-attachments/assets/acf24048-0ac9-47dc-b043-c1bd4e6a20ca" />
<img width="1199" height="719" alt="Screenshot_20260412_001745" src="https://github.com/user-attachments/assets/2a3414a6-aa08-4c7b-85c1-1a3b1516ac09" />
<img width="1217" height="854" alt="Screenshot_20260412_001717" src="https://github.com/user-attachments/assets/fdfde920-60c1-482c-b12e-56a3dd612811" />


### Part of 
Related PR in Hunger Games: https://github.com/openfoodfacts/hunger-games/pull/1479


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side pagination for nutrient insights with incremental loading, prefetching, smoother annotation flow, and a live "Remaining products" counter; updated "no more" view message.

* **Translations**
  * Added English and French translations for the new UI label and message.

* **Tests**
  * Added unit tests covering nutrient-insight fetching and annotation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->