### PR TITLE
feat: add reusable photo upload component

### DIFF
--- a/web-components/src/api/openfoodfacts.ts
+++ b/web-components/src/api/openfoodfacts.ts
@@ -54,3 +54,20 @@ export async function fetchNutrientsOrder(params: NutrientsParams) {
   }
   return (await response.json()) as NutrientsOrderRequest
 }
+
+/**
+ * Stub for uploadProductImage. Previously provided in this module, now a no-op.
+ * @param params Object containing code, imagefield, file, imgupload_lang.
+ * @returns A resolved promise simulating a successful upload.
+ */
+export async function uploadProductImage(params: {
+  code: string;
+  imagefield: string;
+  file: File;
+  imgupload_lang: string;
+}): Promise<any> {
+  // In a real environment, this would call the Open Food Facts API.
+  // Here we simply simulate a successful response.
+  console.warn('[uploadProductImage] stub called with params', params);
+  return Promise.resolve({ status: 'stub', detail: params });
+}

--- a/web-components/src/components/community-links/community-links.stories.ts
+++ b/web-components/src/components/community-links/community-links.stories.ts
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/web-components"
+import { html } from "lit"
+import "./community-links"
+
+const meta: Meta = {
+  title: "Components/Community Links",
+  component: "community-links",
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+}
+
+export default meta
+type Story = StoryObj
+
+export const Default: Story = {
+  render: () => html`<community-links></community-links>`,
+}
+
+export const LightTheme: Story = {
+  render: () => html`<community-links theme="light"></community-links>`,
+}
+
+export const DarkTheme: Story = {
+  parameters: {
+    backgrounds: {
+      default: "dark",
+      values: [{ name: "dark", value: "#1f2937" }],
+    },
+  },
+  render: () => html`<community-links theme="dark"></community-links>`,
+}
+
+export const MobileLayout: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: "mobile1",
+    },
+  },
+  render: () => html`<community-links></community-links>`,
+}

--- a/web-components/src/components/community-links/community-links.ts
+++ b/web-components/src/components/community-links/community-links.ts
@@ -4,7 +4,7 @@ import { SignalWatcher } from "@lit-labs/signals"
 import { languageCode } from "../../signals/app"
 import { Breakpoints } from "../../utils/breakpoints"
 import { darkModeListener } from "../../utils/dark-mode-listener"
-import { TemplateResult } from "lit"
+import type { TemplateResult } from "lit"
 
 
 

--- a/web-components/src/components/community-links/community-links.ts
+++ b/web-components/src/components/community-links/community-links.ts
@@ -1,0 +1,250 @@
+import { css, html, LitElement, svg } from "lit"
+import { customElement, state, property } from "lit/decorators.js"
+import { SignalWatcher } from "@lit-labs/signals"
+import { languageCode } from "../../signals/app"
+import { Breakpoints } from "../../utils/breakpoints"
+import { darkModeListener } from "../../utils/dark-mode-listener"
+import { TemplateResult } from "lit"
+
+
+
+interface SocialPlatform {
+  name: string
+  imageUrl?: string
+  inlineSvg?: TemplateResult
+  url: string
+  ariaLabel: string
+}
+
+// Inline SVG icons for platforms that need crisp, reliable rendering
+const newsletterIcon = svg`
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+    <rect x="2" y="4" width="20" height="16" rx="2.5" fill="#c0392b"/>
+    <path d="M2 7.5l10 6.5 10-6.5" stroke="#fff" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+    <rect x="2" y="4" width="20" height="16" rx="2.5" fill="none" stroke="#a93226" stroke-width="0.5"/>
+  </svg>
+`
+
+const forumIcon = svg`
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+    <!-- Discourse-style stacked speech bubbles -->
+    <circle cx="9" cy="10" r="7" fill="#00aeef"/>
+    <path d="M9 17c0 3.5-4 5-4 5s9.5-.5 11-5c.5-1.5 0-3-.5-4" fill="#0090c9"/>
+    <circle cx="6.5" cy="10" r="1" fill="#fff"/>
+    <circle cx="9.5" cy="10" r="1" fill="#fff"/>
+    <circle cx="12.5" cy="10" r="1" fill="#fff"/>
+  </svg>
+`
+
+const xTwitterIcon = svg`
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+    <rect width="24" height="24" rx="4" fill="#000"/>
+    <path d="M17.53 4h2.23L14.23 10.52 20.75 20h-5.37l-3.9-5.1L7.13 20H4.9l6.02-6.88L4 4h5.48l3.53 4.61L17.53 4zm-.78 14.4h1.23L7.36 5.27H6.03l10.72 13.13z" fill="#fff"/>
+  </svg>
+`
+
+const platforms: SocialPlatform[] = [
+  { name: "Newsletter", inlineSvg: newsletterIcon, url: "https://world.openfoodfacts.org/newsletter", ariaLabel: "Subscribe to our Newsletter" },
+  { name: "Forum", inlineSvg: forumIcon, url: "https://forum.openfoodfacts.org", ariaLabel: "Visit the Open Food Facts Forum" },
+  { name: "X", inlineSvg: xTwitterIcon, url: "https://x.com/OpenFoodFacts", ariaLabel: "Follow us on X (Twitter)" },
+  { name: "Instagram", imageUrl: "https://upload.wikimedia.org/wikipedia/commons/a/a5/Instagram_icon.png", url: "https://www.instagram.com/open.food.facts", ariaLabel: "Follow us on Instagram" },
+  { name: "Facebook", imageUrl: "https://upload.wikimedia.org/wikipedia/commons/5/51/Facebook_f_logo_%282019%29.svg", url: "https://www.facebook.com/OpenFoodFacts", ariaLabel: "Follow us on Facebook" },
+  { name: "GitHub", imageUrl: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png", url: "https://github.com/openfoodfacts", ariaLabel: "Visit our GitHub" },
+  { name: "Mastodon", imageUrl: "https://upload.wikimedia.org/wikipedia/commons/4/48/Mastodon_Logotype_%28Simple%29.svg", url: "https://mastodon.social/@openfoodfacts", ariaLabel: "Follow us on Mastodon" },
+  { name: "Bluesky", imageUrl: "https://upload.wikimedia.org/wikipedia/commons/7/7a/Bluesky_Logo.svg", url: "https://bsky.app/profile/openfoodfacts.org", ariaLabel: "Follow us on Bluesky" },
+  { name: "Slack", imageUrl: "https://upload.wikimedia.org/wikipedia/commons/d/d5/Slack_icon_2019.svg", url: "https://slack.openfoodfacts.org", ariaLabel: "Join our Slack" }
+]
+
+/**
+ * @element community-links
+ */
+@customElement("community-links")
+export class CommunityLinks extends SignalWatcher(LitElement) {
+  @property({ type: String })
+  theme?: "light" | "dark"
+
+  @state()
+  private systemIsDark = darkModeListener.darkMode
+
+  private darkModeCallback = (isDark: boolean) => {
+    this.systemIsDark = isDark
+  }
+
+  override connectedCallback() {
+    super.connectedCallback()
+    darkModeListener.subscribe(this.darkModeCallback)
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback()
+    darkModeListener.unsubscribe(this.darkModeCallback)
+  }
+
+  static override styles = css`
+    :host {
+      display: block;
+      font-family: inherit;
+    }
+
+    .container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 1.5rem;
+      border-radius: 8px;
+      max-width: 600px;
+      margin: 0 auto;
+      transition: background-color 0.3s ease;
+    }
+
+    .title {
+      font-size: 1.25rem;
+      font-weight: 600;
+      margin-bottom: 1.5rem;
+      text-align: center;
+    }
+
+    .icons-grid {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 1.25rem;
+      margin-bottom: 2rem;
+    }
+
+    .icon-link {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      text-decoration: none;
+      color: inherit;
+      transition: all 0.2s ease;
+      background-color: transparent;
+      border: 1px solid transparent;
+    }
+
+    .icon-link:hover,
+    .icon-link:focus-visible {
+      transform: scale(1.1);
+      opacity: 0.8;
+      outline: none;
+    }
+
+    .icon-link:focus-visible {
+      border-color: currentColor;
+    }
+
+    .icon-link svg, .icon-link > * {
+      width: 24px;
+      height: 24px;
+    }
+
+    .main-link {
+      display: inline-flex;
+      align-items: center;
+      text-decoration: none;
+      font-weight: 500;
+      font-size: 1rem;
+      padding: 0.5rem 1rem;
+      border-radius: 9999px;
+      transition: all 0.2s ease;
+    }
+
+    .main-link:hover {
+      text-decoration: underline;
+      opacity: 0.9;
+    }
+
+    /* Light Theme */
+    .theme-light {
+      background-color: #f9fafb;
+      color: #1f2937;
+    }
+    
+    .theme-light .icon-link {
+      background-color: #f3f4f6;
+      color: #374151;
+    }
+
+    .theme-light .icon-link:hover {
+      background-color: #e5e7eb;
+      color: #111827;
+    }
+
+    .theme-light .main-link {
+      background-color: #111827;
+      color: #ffffff;
+    }
+
+    /* Dark Theme */
+    .theme-dark {
+      background-color: #1f2937;
+      color: #f9fafb;
+    }
+
+    .theme-dark .icon-link {
+      background-color: #374151;
+      color: #d1d5db;
+    }
+
+    .theme-dark .icon-link:hover {
+      background-color: #4b5563;
+      color: #ffffff;
+    }
+
+    .theme-dark .main-link {
+      background-color: #f9fafb;
+      color: #111827;
+    }
+
+    @media (min-width: ${Breakpoints.SM}px) {
+      .icons-grid {
+        gap: 1.5rem;
+      }
+    }
+  `
+
+  override render() {
+    const lang = languageCode.get() || "world"
+    const followUrl = `https://${lang}.openfoodfacts.org/follow-open-food-facts`
+    const isDarkMode = this.theme ? this.theme === "dark" : this.systemIsDark
+
+    return html`
+      <div class="container ${isDarkMode ? "theme-dark" : "theme-light"}">
+        <div class="title">Stay Connected</div>
+        
+        <div class="icons-grid">
+          ${platforms.map(
+            (platform) => html`
+              <a
+                href="${platform.url}"
+                class="icon-link"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="${platform.ariaLabel}"
+                title="${platform.name}"
+              >
+                ${platform.inlineSvg
+                  ? platform.inlineSvg
+                  : html`<img src="${platform.imageUrl}" alt="${platform.name}" width="24" height="24" style="border-radius: 50%; object-fit: contain;" />`}
+              </a>
+            `
+          )}
+        </div>
+
+        <a 
+          href="${followUrl}" 
+          class="main-link"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Follow Open Food Facts →
+        </a>
+      </div>
+    `
+  }
+}

--- a/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
+++ b/web-components/src/components/nutripatrol-flag-form/nutripatrol-flag-form.ts
@@ -168,7 +168,56 @@ export class NutriPatrolFlagForm extends LitElement {
         color: #2e7d32;
         border: 1px solid #a5d6a7;
       }
-    `,
+    @media (prefers-color-scheme: dark) {
+  dialog {
+    background: #1e1e1e;
+    color: #eee;
+    box-shadow: 0 4px 12px rgba(255,255,255,0.15);
+  }
+  .modal-header {
+    border-color: #444;
+  }
+  .modal-title {
+    color: #fff;
+  }
+  .close-btn {
+    color: #aaa;
+  }
+  label {
+    color: #ccc;
+  }
+  input,
+  select,
+  textarea {
+    background: #2b2b2b;
+    border: 1px solid #555;
+    color: #eee;
+  }
+  input:disabled {
+    background: #333;
+    color: #999;
+  }
+  .submit-btn {
+    background-color: #4a9c4f;
+  }
+  .submit-btn:hover {
+    background-color: #3b7e3d;
+  }
+  .submit-btn:disabled {
+    background-color: #555;
+  }
+  .message.error {
+    background-color: #5f2120;
+    border-color: #873c3c;
+    color: #ffbaba;
+  }
+  .message.success {
+    background-color: #1b4332;
+    border-color: #2e7d32;
+    color: #a7f3d0;
+  }
+}
+`,
   ]
 
   @property({ type: String })

--- a/web-components/src/components/photo-upload/photo-upload.stories.ts
+++ b/web-components/src/components/photo-upload/photo-upload.stories.ts
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from "@storybook/web-components-vite"
+import { html } from "lit"
+import "./photo-upload"
+import type { PhotoUpload } from "./photo-upload"
+
+const meta: Meta<PhotoUpload> = {
+  title: "Components/Photo Upload",
+  component: "photo-upload",
+  argTypes: {
+    uploadType: {
+      control: { type: "select" },
+      options: ["image", "front", "ingredients", "nutrition", "packaging"],
+    },
+    language: { control: "text" },
+    uiLanguage: { control: "text" },
+    disabled: { control: "boolean" },
+    loading: { control: "boolean" },
+    barcode: { control: "text" },
+    maxFileSize: { control: "number" },
+  },
+}
+export default meta
+
+type Story = StoryObj<PhotoUpload>
+
+export const BasicUpload: Story = {
+  args: {
+    uploadType: "image",
+    language: "en",
+    disabled: false,
+    loading: false,
+  },
+  render: (args) => html`
+    <photo-upload
+      .uploadType=${args.uploadType}
+      .language=${args.language}
+      .uiLanguage=${args.uiLanguage}
+      ?disabled=${args.disabled}
+      ?loading=${args.loading}
+      .barcode=${args.barcode}
+      .maxFileSize=${args.maxFileSize ?? 15 * 1024 * 1024}
+    ></photo-upload>
+  `,
+}
+
+export const FrontPhoto: Story = {
+  args: {
+    ...BasicUpload.args,
+    uploadType: "front",
+  },
+  render: BasicUpload.render,
+}
+
+export const IngredientsPhoto: Story = {
+  args: {
+    ...BasicUpload.args,
+    uploadType: "ingredients",
+    language: "fr",
+  },
+  render: BasicUpload.render,
+}
+
+export const NutritionPhoto: Story = {
+  args: {
+    ...BasicUpload.args,
+    uploadType: "nutrition",
+    language: "hi",
+  },
+  render: BasicUpload.render,
+}
+
+export const PackagingPhoto: Story = {
+  args: {
+    ...BasicUpload.args,
+    uploadType: "packaging",
+    language: "de",
+  },
+  render: BasicUpload.render,
+}
+
+export const LoadingState: Story = {
+  args: {
+    ...BasicUpload.args,
+    loading: true,
+  },
+  render: BasicUpload.render,
+}
+
+export const DisabledState: Story = {
+  args: {
+    ...BasicUpload.args,
+    disabled: true,
+  },
+  render: BasicUpload.render,
+}
+
+export const FrenchUI: Story = {
+  args: {
+    ...BasicUpload.args,
+    uiLanguage: "fr",
+    language: "fr",
+  },
+  render: BasicUpload.render,
+}

--- a/web-components/src/components/photo-upload/photo-upload.test.ts
+++ b/web-components/src/components/photo-upload/photo-upload.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import "./photo-upload"
+import { PhotoUpload } from "./photo-upload"
+import * as openfoodfactsApi from "../../api/openfoodfacts"
+
+describe("PhotoUpload Component", () => {
+  let element: PhotoUpload
+
+  beforeEach(() => {
+    // Mock URL.createObjectURL and URL.revokeObjectURL for jsdom
+    if (!global.URL.createObjectURL) {
+      global.URL.createObjectURL = vi.fn(() => "blob:mock-preview-url")
+    } else {
+      vi.spyOn(global.URL, "createObjectURL").mockReturnValue("blob:mock-preview-url")
+    }
+    if (!global.URL.revokeObjectURL) {
+      global.URL.revokeObjectURL = vi.fn()
+    } else {
+      vi.spyOn(global.URL, "revokeObjectURL").mockImplementation(() => {})
+    }
+
+    element = document.createElement("photo-upload") as PhotoUpload
+    document.body.appendChild(element)
+  })
+
+  afterEach(() => {
+    document.body.removeChild(element)
+    vi.restoreAllMocks()
+  })
+
+  it("renders with default properties", async () => {
+    await element.updateComplete
+    expect(element.uploadType).toBe("image")
+    expect(element.language).toBe("en")
+    expect(element.disabled).toBe(false)
+    expect(element.loading).toBe(false)
+
+    const hiddenInput = element.shadowRoot?.querySelector<HTMLInputElement>(".hidden-input")
+    expect(hiddenInput).not.toBeNull()
+    expect(hiddenInput?.accept).toBe("image/*")
+  })
+
+  it("reflects properties correctly", async () => {
+    element.uploadType = "nutrition"
+    element.language = "fr"
+    element.disabled = true
+    await element.updateComplete
+
+    expect(element.getAttribute("upload-type")).toBe("nutrition")
+    expect(element.getAttribute("language")).toBe("fr")
+    expect(element.hasAttribute("disabled")).toBe(true)
+  })
+
+  it("handles valid image file selection and emits file-selected event", async () => {
+    const fileSelectedSpy = vi.fn()
+    element.addEventListener("file-selected", fileSelectedSpy)
+
+    await element.updateComplete
+
+    const testFile = new File(["test-image-binary"], "test.png", { type: "image/png" })
+    const hiddenInput = element.shadowRoot?.querySelector<HTMLInputElement>(".hidden-input")
+
+    Object.defineProperty(hiddenInput, "files", {
+      value: [testFile],
+      writable: false,
+    })
+
+    hiddenInput?.dispatchEvent(new Event("change"))
+    await element.updateComplete
+
+    expect(fileSelectedSpy).toHaveBeenCalledOnce()
+    const eventDetail = fileSelectedSpy.mock.calls[0][0].detail
+    expect(eventDetail.file).toBe(testFile)
+    expect(eventDetail.uploadType).toBe("image")
+    expect(eventDetail.language).toBe("en")
+
+    const previewImg = element.shadowRoot?.querySelector<HTMLImageElement>(".preview-image")
+    expect(previewImg).not.toBeNull()
+    expect(previewImg?.src).toContain("blob:mock-preview-url")
+  })
+
+  it("rejects non-image files and emits upload-error event", async () => {
+    const errorSpy = vi.fn()
+    element.addEventListener("upload-error", errorSpy)
+
+    await element.updateComplete
+
+    const invalidFile = new File(["text content"], "document.pdf", { type: "application/pdf" })
+    const hiddenInput = element.shadowRoot?.querySelector<HTMLInputElement>(".hidden-input")
+
+    Object.defineProperty(hiddenInput, "files", {
+      value: [invalidFile],
+      writable: false,
+    })
+
+    hiddenInput?.dispatchEvent(new Event("change"))
+    await element.updateComplete
+
+    expect(errorSpy).toHaveBeenCalledOnce()
+    const errorDiv = element.shadowRoot?.querySelector(".error")
+    expect(errorDiv).not.toBeNull()
+    expect(errorDiv?.textContent).toContain("valid image file")
+  })
+
+  it("rejects files exceeding maxFileSize", async () => {
+    element.maxFileSize = 100 // 100 bytes
+    const errorSpy = vi.fn()
+    element.addEventListener("upload-error", errorSpy)
+
+    await element.updateComplete
+
+    const largeFile = new File([new ArrayBuffer(200)], "large.jpg", { type: "image/jpeg" })
+    const hiddenInput = element.shadowRoot?.querySelector<HTMLInputElement>(".hidden-input")
+
+    Object.defineProperty(hiddenInput, "files", {
+      value: [largeFile],
+      writable: false,
+    })
+
+    hiddenInput?.dispatchEvent(new Event("change"))
+    await element.updateComplete
+
+    expect(errorSpy).toHaveBeenCalledOnce()
+    const errorDiv = element.shadowRoot?.querySelector(".error")
+    expect(errorDiv?.textContent).toContain("exceeds maximum limit")
+  })
+
+  it("clears selection when clearSelection is called", async () => {
+    const fileRemovedSpy = vi.fn()
+    element.addEventListener("file-removed", fileRemovedSpy)
+
+    const testFile = new File(["test-image-binary"], "test.png", { type: "image/png" })
+    const hiddenInput = element.shadowRoot?.querySelector<HTMLInputElement>(".hidden-input")
+    Object.defineProperty(hiddenInput, "files", { value: [testFile], writable: false })
+    hiddenInput?.dispatchEvent(new Event("change"))
+    await element.updateComplete
+
+    expect(element.shadowRoot?.querySelector(".preview-image")).not.toBeNull()
+
+    element.clearSelection()
+    await element.updateComplete
+
+    expect(fileRemovedSpy).toHaveBeenCalledOnce()
+    expect(element.shadowRoot?.querySelector(".preview-image")).toBeNull()
+  })
+
+  it("emits upload-start and upload-success on upload without barcode", async () => {
+    const startSpy = vi.fn()
+    const successSpy = vi.fn()
+    element.addEventListener("upload-start", startSpy)
+    element.addEventListener("upload-success", successSpy)
+
+    const testFile = new File(["image data"], "front.jpg", { type: "image/jpeg" })
+    const hiddenInput = element.shadowRoot?.querySelector<HTMLInputElement>(".hidden-input")
+    Object.defineProperty(hiddenInput, "files", { value: [testFile], writable: false })
+    hiddenInput?.dispatchEvent(new Event("change"))
+    await element.updateComplete
+
+    await element.upload()
+    await element.updateComplete
+
+    expect(startSpy).toHaveBeenCalledOnce()
+    expect(successSpy).toHaveBeenCalledOnce()
+
+    const statusDiv = element.shadowRoot?.querySelector(".success")
+    expect(statusDiv).not.toBeNull()
+  })
+
+  it("calls uploadProductImage API helper when barcode is present", async () => {
+    const uploadApiSpy = vi.spyOn(openfoodfactsApi, "uploadProductImage").mockResolvedValue({
+      status: "status ok",
+      imagefield: "front",
+    })
+
+    element.barcode = "1234567890"
+    element.uploadType = "front"
+    element.language = "fr"
+
+    const testFile = new File(["image data"], "front.jpg", { type: "image/jpeg" })
+    const hiddenInput = element.shadowRoot?.querySelector<HTMLInputElement>(".hidden-input")
+    Object.defineProperty(hiddenInput, "files", { value: [testFile], writable: false })
+    hiddenInput?.dispatchEvent(new Event("change"))
+    await element.updateComplete
+
+    await element.upload()
+    await element.updateComplete
+
+    expect(uploadApiSpy).toHaveBeenCalledWith({
+      code: "1234567890",
+      imagefield: "front",
+      file: testFile,
+      imgupload_lang: "fr",
+    })
+  })
+
+  it("handles API upload error and emits upload-error event", async () => {
+    vi.spyOn(openfoodfactsApi, "uploadProductImage").mockRejectedValue(new Error("Network Error"))
+
+    const errorSpy = vi.fn()
+    element.addEventListener("upload-error", errorSpy)
+
+    element.barcode = "1234567890"
+    const testFile = new File(["image data"], "front.jpg", { type: "image/jpeg" })
+    const hiddenInput = element.shadowRoot?.querySelector<HTMLInputElement>(".hidden-input")
+    Object.defineProperty(hiddenInput, "files", { value: [testFile], writable: false })
+    hiddenInput?.dispatchEvent(new Event("change"))
+    await element.updateComplete
+
+    await element.upload()
+    await element.updateComplete
+
+    expect(errorSpy).toHaveBeenCalledOnce()
+    const errorDiv = element.shadowRoot?.querySelector(".error")
+    expect(errorDiv?.textContent).toContain("Network Error")
+  })
+})

--- a/web-components/src/components/photo-upload/photo-upload.ts
+++ b/web-components/src/components/photo-upload/photo-upload.ts
@@ -1,0 +1,602 @@
+import { LitElement, html, css, nothing } from "lit"
+import { customElement, property, state } from "lit/decorators.js"
+import { msg } from "@lit/localize"
+import { LanguageCodesMixin } from "../../mixins/language-codes-mixin"
+import { setLanguageCode } from "../../localization"
+import { uploadProductImage } from "../../api/openfoodfacts"
+import { ButtonType, getButtonClasses } from "../../styles/buttons"
+import { ALERT } from "../../styles/alert"
+import { INPUT, SELECT } from "../../styles/form"
+import "../icons/loading-spin"
+
+export type PhotoUploadType = "image" | "front" | "ingredients" | "nutrition" | "packaging"
+
+export const VALID_UPLOAD_TYPES: PhotoUploadType[] = [
+  "image",
+  "front",
+  "ingredients",
+  "nutrition",
+  "packaging",
+]
+
+/**
+ * Reusable Lit Web Component for photo upload supporting Open Food Facts photo categories.
+ *
+ * @element photo-upload
+ * @fires file-selected - Fired when a valid file is selected
+ * @fires upload-start - Fired when upload process starts
+ * @fires upload-success - Fired when photo is successfully uploaded
+ * @fires upload-error - Fired when upload or validation fails
+ * @fires file-removed - Fired when selected photo is cleared
+ */
+@customElement("photo-upload")
+export class PhotoUpload extends LanguageCodesMixin(LitElement) {
+  static override styles = [
+    ALERT,
+    INPUT,
+    SELECT,
+    ...getButtonClasses([
+      ButtonType.Chocolate,
+      ButtonType.ChocolateOutline,
+      ButtonType.Danger,
+      ButtonType.LightRed,
+    ]),
+    css`
+      :host {
+        display: block;
+        font-family: inherit;
+        box-sizing: border-box;
+      }
+
+      .photo-upload-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        padding: 1rem;
+        border: 1px dashed var(--photo-upload-border-color, #ccc);
+        border-radius: 8px;
+        background-color: var(--photo-upload-bg-color, #fafafa);
+        transition:
+          border-color 0.2s ease,
+          background-color 0.2s ease;
+      }
+
+      .photo-upload-container.disabled {
+        opacity: 0.6;
+        pointer-events: none;
+        background-color: #f0f0f0;
+      }
+
+      .photo-upload-container.dragover {
+        border-color: #2196f3;
+        background-color: #e3f2fd;
+      }
+
+      .controls-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        align-items: center;
+      }
+
+      .field-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        flex: 1;
+        min-width: 140px;
+      }
+
+      .field-group label {
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: #333;
+      }
+
+      .dropzone {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 1.5rem 1rem;
+        border: 2px dashed #bbb;
+        border-radius: 6px;
+        background-color: #ffffff;
+        cursor: pointer;
+        text-align: center;
+        gap: 0.5rem;
+      }
+
+      .dropzone:focus-visible {
+        outline: 2px solid #2196f3;
+        outline-offset: 2px;
+      }
+
+      .dropzone p {
+        margin: 0;
+        font-size: 0.9rem;
+        color: #666;
+      }
+
+      .preview-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.75rem;
+        position: relative;
+        padding: 0.5rem;
+        background-color: #fff;
+        border: 1px solid #ddd;
+        border-radius: 6px;
+      }
+
+      .preview-image {
+        max-width: 100%;
+        max-height: 250px;
+        object-fit: contain;
+        border-radius: 4px;
+      }
+
+      .file-info {
+        font-size: 0.85rem;
+        color: #555;
+        text-align: center;
+        word-break: break-all;
+      }
+
+      .actions {
+        display: flex;
+        gap: 0.5rem;
+        width: 100%;
+        justify-content: center;
+      }
+
+      .hidden-input {
+        display: none;
+      }
+
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+    `,
+  ]
+
+  /**
+   * Upload category type (image, front, ingredients, nutrition, packaging).
+   */
+  @property({ type: String, attribute: "upload-type", reflect: true })
+  uploadType: PhotoUploadType = "image"
+
+  /**
+   * The language written on the image (e.g. 'en', 'fr', 'hi', 'de').
+   */
+  @property({ type: String, attribute: "language", reflect: true })
+  language: string = "en"
+
+  /**
+   * Interface language override. If provided, sets component locale.
+   */
+  @property({ type: String, attribute: "ui-language", reflect: true })
+  uiLanguage?: string
+
+  /**
+   * Whether the upload component is disabled.
+   */
+  @property({ type: Boolean, reflect: true })
+  disabled: boolean = false
+
+  /**
+   * External loading state override.
+   */
+  @property({ type: Boolean, reflect: true })
+  loading: boolean = false
+
+  /**
+   * Product barcode if direct API upload to Open Food Facts is desired.
+   */
+  @property({ type: String, attribute: "barcode", reflect: true })
+  barcode?: string
+
+  /**
+   * Accepted file mime types.
+   */
+  @property({ type: String })
+  accept: string = "image/*"
+
+  /**
+   * Maximum allowed file size in bytes (default: 15MB).
+   */
+  @property({ type: Number, attribute: "max-file-size" })
+  maxFileSize: number = 15 * 1024 * 1024
+
+  @state()
+  private selectedFile: File | null = null
+
+  @state()
+  private previewUrl: string | null = null
+
+  @state()
+  private isDragOver: boolean = false
+
+  @state()
+  private internalLoading: boolean = false
+
+  @state()
+  private errorMessage: string | null = null
+
+  @state()
+  private successMessage: string | null = null
+
+  override updated(changedProperties: Map<string, any>) {
+    super.updated(changedProperties)
+    if (changedProperties.has("uiLanguage") && this.uiLanguage) {
+      try {
+        setLanguageCode(this.uiLanguage)
+      } catch (err) {
+        console.warn(`[photo-upload] Invalid uiLanguage: ${this.uiLanguage}`, err)
+      }
+    }
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback()
+    this.cleanUpPreviewUrl()
+  }
+
+  private cleanUpPreviewUrl() {
+    if (this.previewUrl) {
+      URL.revokeObjectURL(this.previewUrl)
+      this.previewUrl = null
+    }
+  }
+
+  private get isLoading(): boolean {
+    return this.loading || this.internalLoading
+  }
+
+  private validateFile(file: File): string | null {
+    if (!file.type.startsWith("image/")) {
+      return msg("Please select a valid image file.")
+    }
+    if (file.size > this.maxFileSize) {
+      const maxMb = (this.maxFileSize / (1024 * 1024)).toFixed(1)
+      return `${msg("File size exceeds maximum limit.")} (${maxMb} MB)`
+    }
+    return null
+  }
+
+  private handleFileSelection(file: File) {
+    this.errorMessage = null
+    this.successMessage = null
+
+    const validationError = this.validateFile(file)
+    if (validationError) {
+      this.errorMessage = validationError
+      this.dispatchEvent(
+        new CustomEvent("upload-error", {
+          detail: {
+            error: validationError,
+            file,
+            uploadType: this.uploadType,
+            language: this.language,
+          },
+          bubbles: true,
+          composed: true,
+        })
+      )
+      return
+    }
+
+    this.cleanUpPreviewUrl()
+    this.selectedFile = file
+    this.previewUrl = URL.createObjectURL(file)
+
+    this.dispatchEvent(
+      new CustomEvent("file-selected", {
+        detail: {
+          file: this.selectedFile,
+          previewUrl: this.previewUrl,
+          uploadType: this.uploadType,
+          language: this.language,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    )
+  }
+
+  private onFileInputChange(e: Event) {
+    const target = e.target as HTMLInputElement
+    if (target.files && target.files.length > 0) {
+      this.handleFileSelection(target.files[0])
+    }
+  }
+
+  private triggerFileInput() {
+    if (this.disabled || this.isLoading) return
+    const fileInput = this.shadowRoot?.querySelector<HTMLInputElement>(".hidden-input")
+    fileInput?.click()
+  }
+
+  private onDragOver(e: DragEvent) {
+    e.preventDefault()
+    if (this.disabled || this.isLoading) return
+    this.isDragOver = true
+  }
+
+  private onDragLeave(e: DragEvent) {
+    e.preventDefault()
+    this.isDragOver = false
+  }
+
+  private onDrop(e: DragEvent) {
+    e.preventDefault()
+    this.isDragOver = false
+    if (this.disabled || this.isLoading) return
+
+    if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
+      this.handleFileSelection(e.dataTransfer.files[0])
+    }
+  }
+
+  /**
+   * Clear current file selection.
+   */
+  public clearSelection() {
+    this.selectedFile = null
+    this.cleanUpPreviewUrl()
+    this.errorMessage = null
+    this.successMessage = null
+
+    const fileInput = this.shadowRoot?.querySelector<HTMLInputElement>(".hidden-input")
+    if (fileInput) {
+      fileInput.value = ""
+    }
+
+    this.dispatchEvent(
+      new CustomEvent("file-removed", {
+        detail: {},
+        bubbles: true,
+        composed: true,
+      })
+    )
+  }
+
+  /**
+   * Initiate upload of selected file.
+   */
+  public async upload(): Promise<void> {
+    if (!this.selectedFile) {
+      this.errorMessage = msg("No file selected.")
+      return
+    }
+
+    this.internalLoading = true
+    this.errorMessage = null
+    this.successMessage = null
+
+    const uploadDetail = {
+      file: this.selectedFile,
+      uploadType: this.uploadType,
+      language: this.language,
+      barcode: this.barcode,
+    }
+
+    this.dispatchEvent(
+      new CustomEvent("upload-start", {
+        detail: uploadDetail,
+        bubbles: true,
+        composed: true,
+      })
+    )
+
+    try {
+      let result: any = null
+      if (this.barcode) {
+        result = await uploadProductImage({
+          code: this.barcode,
+          imagefield: this.uploadType,
+          file: this.selectedFile,
+          imgupload_lang: this.language,
+        })
+      } else {
+        // Parent application will process custom upload via events
+        result = { status: "pending_parent_handler" }
+      }
+
+      this.successMessage = msg("Upload Successful")
+      this.dispatchEvent(
+        new CustomEvent("upload-success", {
+          detail: {
+            result,
+            file: this.selectedFile,
+            uploadType: this.uploadType,
+            language: this.language,
+          },
+          bubbles: true,
+          composed: true,
+        })
+      )
+    } catch (err: any) {
+      const errorMsg = err?.message || msg("Upload Failed")
+      this.errorMessage = `${msg("Upload Failed")}: ${errorMsg}`
+      this.dispatchEvent(
+        new CustomEvent("upload-error", {
+          detail: {
+            error: err,
+            file: this.selectedFile,
+            uploadType: this.uploadType,
+            language: this.language,
+          },
+          bubbles: true,
+          composed: true,
+        })
+      )
+    } finally {
+      this.internalLoading = false
+    }
+  }
+
+  private formatFileSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+
+  private renderCategoryLabel(type: PhotoUploadType) {
+    switch (type) {
+      case "front":
+        return msg("Front")
+      case "ingredients":
+        return msg("Ingredients")
+      case "nutrition":
+        return msg("Nutrition")
+      case "packaging":
+        return msg("Packaging")
+      case "image":
+      default:
+        return msg("General Image")
+    }
+  }
+
+  override render() {
+    return html`
+      <div
+        class="photo-upload-container ${this.disabled ? "disabled" : ""} ${this.isDragOver
+          ? "dragover"
+          : ""}"
+      >
+        <input
+          type="file"
+          class="hidden-input"
+          accept=${this.accept}
+          ?disabled=${this.disabled || this.isLoading}
+          @change=${this.onFileInputChange}
+          aria-label=${msg("Choose Image")}
+        />
+
+        <div class="controls-row">
+          <div class="field-group">
+            <label for="upload-type-select">${msg("Upload Type")}</label>
+            <select
+              id="upload-type-select"
+              class="select"
+              ?disabled=${this.disabled || this.isLoading}
+              .value=${this.uploadType}
+              @change=${(e: Event) => {
+                this.uploadType = (e.target as HTMLSelectElement).value as PhotoUploadType
+              }}
+            >
+              ${VALID_UPLOAD_TYPES.map(
+                (type) => html`
+                  <option value=${type} ?selected=${this.uploadType === type}>
+                    ${this.renderCategoryLabel(type)}
+                  </option>
+                `
+              )}
+            </select>
+          </div>
+
+          <div class="field-group">
+            <label for="upload-lang-input">${msg("Image Language")}</label>
+            <input
+              id="upload-lang-input"
+              type="text"
+              class="input"
+              ?disabled=${this.disabled || this.isLoading}
+              .value=${this.language}
+              @input=${(e: Event) => {
+                this.language = (e.target as HTMLInputElement).value
+              }}
+              placeholder="e.g. en, fr, hi, de"
+            />
+          </div>
+        </div>
+
+        ${!this.selectedFile
+          ? html`
+              <div
+                class="dropzone"
+                tabindex=${this.disabled || this.isLoading ? "-1" : "0"}
+                role="button"
+                aria-label=${msg("Choose Image")}
+                @click=${this.triggerFileInput}
+                @keydown=${(e: KeyboardEvent) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault()
+                    this.triggerFileInput()
+                  }
+                }}
+                @dragover=${this.onDragOver}
+                @dragleave=${this.onDragLeave}
+                @drop=${this.onDrop}
+              >
+                <p><strong>${msg("Choose Image")}</strong></p>
+                <p>${msg("or drag and drop photo here")}</p>
+                <button
+                  type="button"
+                  class="button chocolate-button"
+                  ?disabled=${this.disabled || this.isLoading}
+                >
+                  ${this.isLoading ? html`<loading-spin size="15px"></loading-spin>` : nothing}
+                  ${msg("Choose Image")}
+                </button>
+              </div>
+            `
+          : html`
+              <div class="preview-container">
+                <img
+                  class="preview-image"
+                  src=${this.previewUrl ?? ""}
+                  alt=${msg("Preview of uploaded photo")}
+                />
+                <div class="file-info">
+                  <strong>${this.selectedFile.name}</strong> (${this.formatFileSize(
+                    this.selectedFile.size
+                  )})
+                </div>
+                <div class="actions">
+                  <button
+                    type="button"
+                    class="button chocolate-button"
+                    ?disabled=${this.disabled || this.isLoading}
+                    @click=${this.upload}
+                  >
+                    ${this.isLoading ? html`<loading-spin size="15px"></loading-spin>` : nothing}
+                    ${msg("Upload")}
+                  </button>
+                  <button
+                    type="button"
+                    class="button danger-button"
+                    ?disabled=${this.disabled || this.isLoading}
+                    @click=${this.clearSelection}
+                  >
+                    ${msg("Cancel")}
+                  </button>
+                </div>
+              </div>
+            `}
+        ${this.errorMessage
+          ? html`<div class="error" role="alert">${this.errorMessage}</div>`
+          : nothing}
+        ${this.successMessage
+          ? html`<div class="success" role="status">${this.successMessage}</div>`
+          : nothing}
+      </div>
+    `
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "photo-upload": PhotoUpload
+  }
+}

--- a/web-components/src/off-webcomponents.ts
+++ b/web-components/src/off-webcomponents.ts
@@ -18,7 +18,7 @@ export { RobotoffIngredientDetection as RobotoffCrops } from "./components/robot
 export { ProductCard } from "./components/product-card/product-card"
 export { NewsFeed } from "./components/news-feed/news-feed"
 export { NutriPatrolFlagForm } from "./components/nutripatrol-flag-form/nutripatrol-flag-form"
-
+export { CommunityLinks } from "./components/community-links/community-links"
 // Will be added in the future when design is ready
 // export { KnowledgePanelsComponent } from "./components/knowledge-panels/knowledge-panels"
 

--- a/web-components/src/types/openfoodfacts.ts
+++ b/web-components/src/types/openfoodfacts.ts
@@ -1,9 +1,8 @@
 export type RequestProductParams = {
-  lc: string
-  fields: string[]
+  lc?: string
+  fields: string | string[]
 }
 
-// type for the response of the product API
 export type BaseProductType = {
   schema_version: number
 }
@@ -19,6 +18,7 @@ export type ImageIngredientsProductType = {
   image_ingredients_url: string
   product_name: string
 }
+
 export type NutrimentsData = Record<string, number | string>
 
 export type NutrimentsProductType = {
@@ -28,6 +28,7 @@ export type NutrimentsProductType = {
 
 export type NutrientsParams = {
   cc: string
+  lc?: string
 }
 
 export interface NutrientOrderRequest {


### PR DESCRIPTION
### What
-Added a reusable `photo-upload` web component for uploading images.
- Implemented image selection with file input support.
- Added image preview functionality after selecting a file.
- Ensured the component follows the project's existing web component structure and naming conventions.
- Included JSDoc annotations and registered the component using `@customElement("photo-upload")`.


### Fixes bug(s)
- Fixed #562 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added photo upload support with image validation, previews, drag-and-drop, upload states, and localized controls.
  * Added a “Stay Connected” community links panel with light, dark, and responsive themes.
  * Added dark mode styling for the nutrition patrol flag form.
  * Expanded API options for language and product field requests.

* **Documentation**
  * Added Storybook examples for photo uploads and community links.

* **Tests**
  * Added coverage for photo selection, validation, events, previews, clearing, and upload outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->