### PR TITLE
fix: change placeholder-image style to enhance appearance in product-…

### DIFF
--- a/web-components/src/components/product-card/product-card.ts
+++ b/web-components/src/components/product-card/product-card.ts
@@ -162,7 +162,7 @@ export class ProductCard extends LitElement {
       width: 100%;
       border-radius: 0.5rem;
       background-color: transparent;
-      object-fit: cover;
+      object-fit: contain;
       opacity: 0.7;
       overflow: hidden;
     }


### PR DESCRIPTION
### What
- The `object-fit` style of the product placeholder image is changed from `cover` to `contain`
- So this ensures the image is fully visible rather than filling the container

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
before
<img width="1214" height="428" alt="image" src="https://github.com/user-attachments/assets/64c0536b-2b50-4955-b071-4a59da0a5eae" />

after
<img width="1214" height="428" alt="image" src="https://github.com/user-attachments/assets/abe62ace-5032-4668-87e3-6be7bf912718" />

### Fixes bug(s)
- <!-- #1, #2 and #3 (change by appropriate issues) --> openfoodfacts/openfoodfacts-explorer#1696


### Part of 
- <!-- #1, please use the most granular issue possible --> openfoodfacts/openfoodfacts-explorer#1696


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated product card placeholder images to fit within their containers without cropping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->