### PR TITLE
fix: clean up event listener lifecycles

### DIFF
--- a/web-components/src/components/folksonomy/delete-modal.ts
+++ b/web-components/src/components/folksonomy/delete-modal.ts
@@ -157,7 +157,7 @@ export class DeleteModal extends LitElement {
     this.open = false
   }
 
-  private handleKeyDown(event: KeyboardEvent) {
+  private handleKeyDown = (event: KeyboardEvent) => {
     if (event.key === "Escape") {
       this.handleCancel(event)
     }
@@ -165,12 +165,12 @@ export class DeleteModal extends LitElement {
 
   override connectedCallback() {
     super.connectedCallback()
-    document.addEventListener("keydown", this.handleKeyDown.bind(this))
+    document.addEventListener("keydown", this.handleKeyDown)
   }
 
   override disconnectedCallback() {
+    document.removeEventListener("keydown", this.handleKeyDown)
     super.disconnectedCallback()
-    document.removeEventListener("keydown", this.handleKeyDown.bind(this))
   }
 
   override render() {

--- a/web-components/src/components/robotoff-ingredient-spellcheck/text-corrector.ts
+++ b/web-components/src/components/robotoff-ingredient-spellcheck/text-corrector.ts
@@ -277,33 +277,12 @@ export class TextCorrector extends TextDiffMixin(LitElement) {
     }
   }
   /**
-   * Called when the component is first updated.
-   * Adds an event listener for the keydown event if keyboard mode is enabled.
-   */
-  override firstUpdated() {
-    if (this.enableKeyboardMode) {
-      this.form!.addEventListener("keydown", this.handleKeyboardShortcut.bind(this))
-    }
-  }
-
-  /**
-   * Called when the component is disconnected from the DOM.
-   * Removes the event listener for the keydown event if keyboard mode is enabled.
-   */
-  override disconnectedCallback() {
-    super.disconnectedCallback()
-    if (this.enableKeyboardMode) {
-      this.form!.removeEventListener("keydown", this.handleKeyboardShortcut.bind(this))
-    }
-  }
-
-  /**
    * Renders the component.
    * @returns {TemplateResult} The rendered component.
    */
   override render() {
     return html`
-      <form @submit=${this.confirmText}>
+      <form @submit=${this.confirmText} @keydown=${this.handleKeyboardShortcut}>
         <div>
           ${this.isEditMode
             ? html`<text-corrector-highlight
@@ -981,7 +960,7 @@ export class TextCorrector extends TextDiffMixin(LitElement) {
    * Handles the keyboard shortcuts.
    * @param {KeyboardEvent} event - The keyboard event.
    */
-  private handleKeyboardShortcut(event: KeyboardEvent) {
+  private handleKeyboardShortcut = (event: KeyboardEvent) => {
     if (!this.enableKeyboardMode || this.isEditMode) {
       return
     }

--- a/web-components/src/components/shared/zoomable-image.ts
+++ b/web-components/src/components/shared/zoomable-image.ts
@@ -234,14 +234,20 @@ export class ZoomableImage extends MessageDisplayMixinElement {
     this.initCropper()
   }
 
+  override connectedCallback() {
+    super.connectedCallback()
+    // firstUpdated() is only called once; reconnecting needs to restore the listener.
+    if (this.canvasElement) {
+      this.initZoomLimit()
+    }
+  }
+
   /**
    * Called when the component is disconnected from the DOM.
    * Used to remove the event listener from the cropper canvas.
    */
   override disconnectedCallback(): void {
-    this.canvasElement.removeEventListener("actionstart", (e) => {
-      this.onCropperCanvasAction(e as CropperActionEvent)
-    })
+    this.canvasElement?.removeEventListener("action", this.handleCropperCanvasAction)
     super.disconnectedCallback()
   }
 
@@ -250,9 +256,11 @@ export class ZoomableImage extends MessageDisplayMixinElement {
    * This is used to prevent the user from zooming in or out too much.
    */
   initZoomLimit() {
-    this.canvasElement.addEventListener("action", (e) => {
-      this.onCropperCanvasAction(e as CropperActionEvent)
-    })
+    this.canvasElement.addEventListener("action", this.handleCropperCanvasAction)
+  }
+
+  private handleCropperCanvasAction = (event: Event) => {
+    this.onCropperCanvasAction(event as CropperActionEvent)
   }
 
   resetRotatation() {

--- a/web-components/src/directives/click-outside.ts
+++ b/web-components/src/directives/click-outside.ts
@@ -4,14 +4,10 @@ import { AsyncDirective } from "lit/async-directive.js"
 /**
  * A Lit directive that detects clicks outside a specified element and triggers a callback function.
  */
-
-/**
- * A Lit directive that detects clicks outside a specified element and triggers a callback function.
- */
 class ClickOutsideDirective extends AsyncDirective {
   private element: HTMLElement | null = null
   private callback: (() => void) | null = null
-  private clickIsTriggered: boolean = false
+  private animationFrameId: number | null = null
 
   /**
    * Initializes the ClickOutsideDirective.
@@ -21,7 +17,6 @@ class ClickOutsideDirective extends AsyncDirective {
     super(part)
     this.element = part.element as HTMLElement
     this.addEventListener()
-    this.clickIsTriggered = false
   }
 
   /**
@@ -46,15 +41,6 @@ class ClickOutsideDirective extends AsyncDirective {
   }
 
   /**
-   * Catches the event click from the element.
-   * Use this trick because element.contains doesn't work with shadow dom
-   * @returns {void}
-   */
-  catchEventClickFromElement() {
-    this.clickIsTriggered = true
-  }
-
-  /**
    * Cleans up the directive when it is disconnected.
    */
   override disconnected() {
@@ -62,12 +48,19 @@ class ClickOutsideDirective extends AsyncDirective {
   }
 
   /**
+   * Reattach the document listener when Lit reconnects the directive.
+   */
+  override reconnected() {
+    this.addEventListener()
+  }
+
+  /**
    * Adds an event listener to detect clicks outside the element.
    */
   private addEventListener() {
     // Add a small delay to ensure the event listener is added after the initial render
-    requestAnimationFrame(() => {
-      this.element!.addEventListener("click", () => this.catchEventClickFromElement())
+    this.animationFrameId = requestAnimationFrame(() => {
+      this.animationFrameId = null
       document.addEventListener("click", this.handleClick)
     })
   }
@@ -76,7 +69,10 @@ class ClickOutsideDirective extends AsyncDirective {
    * Removes the event listener that detects clicks outside the element.
    */
   private removeEventListener() {
-    this.element!.removeEventListener("click", () => this.catchEventClickFromElement)
+    if (this.animationFrameId !== null) {
+      cancelAnimationFrame(this.animationFrameId)
+      this.animationFrameId = null
+    }
     document.removeEventListener("click", this.handleClick)
   }
 
@@ -84,10 +80,9 @@ class ClickOutsideDirective extends AsyncDirective {
    * Handles the click event to detect clicks outside the element.
    * @param {MouseEvent} event - The mouse event.
    */
-  private handleClick = () => {
-    // Use this trick because element.contains doesn't work with shadow dom
-    if (this.clickIsTriggered) {
-      this.clickIsTriggered = false
+  private handleClick = (event: MouseEvent) => {
+    // composedPath() also works when the clicked element is inside a shadow root.
+    if (this.element && event.composedPath().includes(this.element)) {
       return
     }
     this.callback?.()


### PR DESCRIPTION
## Problem
Several components registered DOM listeners with fresh bound or anonymous functions. Because removeEventListener requires the exact same function object, those listeners were never removed, causing stale handlers and possible duplicate callbacks after repeated mounting.

The zoomable image had the same add/remove mismatch for Cropper events. Its listener was initialized only from firstUpdated, so correcting cleanup without changing initialization would leave it inactive after a disconnect and reconnect. The click-outside directive used an element-level flag and an anonymous listener, making cleanup unreliable and not directly identifying whether a click came from inside a shadow tree.

## Fix
- Use stable handler references for the modal, text-corrector, zoomable-image, and click-outside listeners.
- Remove and restore zoom and click-outside listeners through their lifecycle hooks.
- Bind text-corrector keyboard shortcuts declaratively with Lit, so Lit manages the listener across reconnects and updates.
- Detect click-outside events with event.composedPath() and cancel pending animation-frame registration during cleanup.

## Validation
- ESLint passes.
- Vitest passes: 151 tests.
- git diff --check passes.