### PR TITLE
fix: correct configuration element tag map

### DIFF
--- a/web-components/src/components/shared/off-webcomponents-configuration.ts
+++ b/web-components/src/components/shared/off-webcomponents-configuration.ts
@@ -149,6 +149,6 @@ export class OffWebcomponentsConfiguration extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "off-webcomponent-configuration": OffWebcomponentsConfiguration
+    "off-webcomponents-configuration": OffWebcomponentsConfiguration
   }
 }


### PR DESCRIPTION
## Summary
- Correct the global HTMLElementTagNameMap key to match the registered `off-webcomponents-configuration` element.

## Validation
- `npm run lint:eslint -- src/components/shared/off-webcomponents-configuration.ts`