### PR TITLE
fix: align API types and upgrade Open Food Facts SDK

### DIFF
--- a/web-components/package-lock.json
+++ b/web-components/package-lock.json
@@ -25,7 +25,7 @@
         "@custom-elements-manifest/analyzer": "^0.11.0",
         "@lit/localize-tools": "^0.8.0",
         "@open-wc/testing": "^4.0.0",
-        "@openfoodfacts/openfoodfacts-nodejs": "^2.0.0-alpha.18",
+        "@openfoodfacts/openfoodfacts-nodejs": "^2.0.0-alpha.33",
         "@storybook/addon-a11y": "^10.3.6",
         "@storybook/addon-docs": "^10.3.6",
         "@storybook/addon-vitest": "^10.3.6",
@@ -1626,13 +1626,14 @@
       }
     },
     "node_modules/@openfoodfacts/openfoodfacts-nodejs": {
-      "version": "2.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/@openfoodfacts/openfoodfacts-nodejs/-/openfoodfacts-nodejs-2.0.0-alpha.19.tgz",
-      "integrity": "sha512-FUWRp5iPDDV9IQtXwfDowFg3EUPjnohF7zH3Cb0PddhnB+HqE/Uon9O5mODU6RhrOCfBASEJLLZYHrW+sjOJ0Q==",
+      "version": "2.0.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/@openfoodfacts/openfoodfacts-nodejs/-/openfoodfacts-nodejs-2.0.0-alpha.33.tgz",
+      "integrity": "sha512-KBHOmzX3Ms4tBlIrUUoBVt/SG0wRS41ulGX9cH6jCbmCp41LldTk6CKUNoohUFibdxMWYrhLQfL7oAqPgTDtCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "openapi-fetch": "^0.14.0"
+        "jwt-decode": "4.0.0",
+        "openapi-fetch": "^0.17.0"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -8526,6 +8527,16 @@
         "node": "*"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keygrip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -9600,19 +9611,19 @@
       }
     },
     "node_modules/openapi-fetch": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.0.tgz",
-      "integrity": "sha512-PshIdm1NgdLvb05zp8LqRQMNSKzIlPkyMxYFxwyHR+UlKD4t2nUjkDhNxeRbhRSEd3x5EUNh2w5sJYwkhOH4fg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.17.0.tgz",
+      "integrity": "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "openapi-typescript-helpers": "^0.0.15"
+        "openapi-typescript-helpers": "^0.1.0"
       }
     },
     "node_modules/openapi-typescript-helpers": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
-      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.1.0.tgz",
+      "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
       "dev": true,
       "license": "MIT"
     },

--- a/web-components/package-lock.json
+++ b/web-components/package-lock.json
@@ -25,7 +25,7 @@
         "@custom-elements-manifest/analyzer": "^0.11.0",
         "@lit/localize-tools": "^0.8.0",
         "@open-wc/testing": "^4.0.0",
-        "@openfoodfacts/openfoodfacts-nodejs": "^2.0.0-alpha.18",
+        "@openfoodfacts/openfoodfacts-nodejs": "^2.0.0-alpha.33",
         "@storybook/addon-a11y": "^10.5.10",
         "@storybook/addon-docs": "^10.5.10",
         "@storybook/addon-vitest": "^10.5.10",
@@ -1622,13 +1622,14 @@
       }
     },
     "node_modules/@openfoodfacts/openfoodfacts-nodejs": {
-      "version": "2.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/@openfoodfacts/openfoodfacts-nodejs/-/openfoodfacts-nodejs-2.0.0-alpha.19.tgz",
-      "integrity": "sha512-FUWRp5iPDDV9IQtXwfDowFg3EUPjnohF7zH3Cb0PddhnB+HqE/Uon9O5mODU6RhrOCfBASEJLLZYHrW+sjOJ0Q==",
+      "version": "2.0.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/@openfoodfacts/openfoodfacts-nodejs/-/openfoodfacts-nodejs-2.0.0-alpha.33.tgz",
+      "integrity": "sha512-KBHOmzX3Ms4tBlIrUUoBVt/SG0wRS41ulGX9cH6jCbmCp41LldTk6CKUNoohUFibdxMWYrhLQfL7oAqPgTDtCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "openapi-fetch": "^0.14.0"
+        "jwt-decode": "4.0.0",
+        "openapi-fetch": "^0.17.0"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -7394,6 +7395,16 @@
         "node": "*"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keygrip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -8417,19 +8428,19 @@
       }
     },
     "node_modules/openapi-fetch": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.0.tgz",
-      "integrity": "sha512-PshIdm1NgdLvb05zp8LqRQMNSKzIlPkyMxYFxwyHR+UlKD4t2nUjkDhNxeRbhRSEd3x5EUNh2w5sJYwkhOH4fg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.17.0.tgz",
+      "integrity": "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "openapi-typescript-helpers": "^0.0.15"
+        "openapi-typescript-helpers": "^0.1.0"
       }
     },
     "node_modules/openapi-typescript-helpers": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
-      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.1.0.tgz",
+      "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
       "dev": true,
       "license": "MIT"
     },

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -66,7 +66,7 @@
     "@custom-elements-manifest/analyzer": "^0.11.0",
     "@lit/localize-tools": "^0.8.0",
     "@open-wc/testing": "^4.0.0",
-    "@openfoodfacts/openfoodfacts-nodejs": "^2.0.0-alpha.18",
+    "@openfoodfacts/openfoodfacts-nodejs": "^2.0.0-alpha.33",
     "@storybook/addon-a11y": "^10.3.6",
     "@storybook/addon-docs": "^10.3.6",
     "@storybook/addon-vitest": "^10.3.6",

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -66,7 +66,7 @@
     "@custom-elements-manifest/analyzer": "^0.11.0",
     "@lit/localize-tools": "^0.8.0",
     "@open-wc/testing": "^4.0.0",
-    "@openfoodfacts/openfoodfacts-nodejs": "^2.0.0-alpha.18",
+    "@openfoodfacts/openfoodfacts-nodejs": "^2.0.0-alpha.33",
     "@storybook/addon-a11y": "^10.5.10",
     "@storybook/addon-docs": "^10.5.10",
     "@storybook/addon-vitest": "^10.5.10",

--- a/web-components/src/api/robotoff.test.ts
+++ b/web-components/src/api/robotoff.test.ts
@@ -19,17 +19,18 @@ vi.mock("../signals/app", () => ({
   },
 }))
 
-vi.mock("@openfoodfacts/openfoodfacts-nodejs", () => ({
-  Robotoff: vi.fn().mockImplementation(function () {
-    return {
-      annotate: vi.fn().mockResolvedValue({ status: "saved" }),
-    }
-  }),
-}))
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+
+const lastRequest = () => (global.fetch as any).mock.calls.at(-1)[0] as Request
+const lastRequestOptions = () => (global.fetch as any).mock.calls.at(-1)[1]
 
 describe("Robotoff API", () => {
   beforeEach(() => {
-    global.fetch = vi.fn()
+    global.fetch = vi.fn().mockResolvedValue(jsonResponse({ status: "saved" }))
     vi.clearAllMocks()
   })
 
@@ -46,54 +47,39 @@ describe("Robotoff API", () => {
         ],
       }
 
-      ;(global.fetch as any).mockResolvedValue({
-        ok: true,
-        json: async () => mockQuestions,
-      })
+      ;(global.fetch as any).mockResolvedValue(jsonResponse(mockQuestions))
 
       const result = await robotoff.questionsByProductCode("1234567890123")
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        "https://robotoff.openfoodfacts.org/api/v1/questions/1234567890123?lang=en",
-        { credentials: "include" }
+      expect(lastRequest().url).toBe(
+        "https://robotoff.openfoodfacts.org/api/v1/questions/1234567890123?lang=en"
       )
+      expect(lastRequestOptions()).toEqual({ credentials: "include" })
       expect(result).toEqual(mockQuestions)
     })
 
     it("should use provided language parameter", async () => {
-      ;(global.fetch as any).mockResolvedValue({
-        ok: true,
-        json: async () => ({ questions: [] }),
-      })
+      ;(global.fetch as any).mockResolvedValue(jsonResponse({ questions: [] }))
 
       await robotoff.questionsByProductCode("123", { lang: "fr" })
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        "https://robotoff.openfoodfacts.org/api/v1/questions/123?lang=fr",
-        { credentials: "include" }
+      expect(lastRequest().url).toBe(
+        "https://robotoff.openfoodfacts.org/api/v1/questions/123?lang=fr"
       )
+      expect(lastRequestOptions()).toEqual({ credentials: "include" })
     })
 
     it("should handle additional parameters", async () => {
-      ;(global.fetch as any).mockResolvedValue({
-        ok: true,
-        json: async () => ({ questions: [] }),
-      })
+      ;(global.fetch as any).mockResolvedValue(jsonResponse({ questions: [] }))
 
       await robotoff.questionsByProductCode("123", {
         count: 10,
         insight_types: "ingredient",
       })
 
-      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("count=10"), {
-        credentials: "include",
-      })
-      expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("insight_types=ingredient"),
-        {
-          credentials: "include",
-        }
-      )
+      expect(lastRequest().url).toContain("count=10")
+      expect(lastRequest().url).toContain("insight_types=ingredient")
+      expect(lastRequestOptions()).toEqual({ credentials: "include" })
     })
 
     it("should handle network errors gracefully", async () => {
@@ -105,7 +91,9 @@ describe("Robotoff API", () => {
     it("should handle malformed JSON responses", async () => {
       ;(global.fetch as any).mockResolvedValue({
         ok: true,
-        json: async () => {
+        status: 200,
+        headers: new Headers({ "Content-Type": "application/json" }),
+        text: async () => {
           throw new Error("Invalid JSON")
         },
       })
@@ -126,25 +114,17 @@ describe("Robotoff API", () => {
         ],
       }
 
-      ;(global.fetch as any).mockResolvedValue({
-        ok: true,
-        json: async () => mockInsights,
-      })
+      ;(global.fetch as any).mockResolvedValue(jsonResponse(mockInsights))
 
       const result = await robotoff.insights()
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        "https://robotoff.openfoodfacts.org/api/v1/insights?",
-        { credentials: "include" }
-      )
+      expect(lastRequest().url).toBe("https://robotoff.openfoodfacts.org/api/v1/insights")
+      expect(lastRequestOptions()).toEqual({ credentials: "include" })
       expect(result).toEqual(mockInsights)
     })
 
     it("should handle request parameters", async () => {
-      ;(global.fetch as any).mockResolvedValue({
-        ok: true,
-        json: async () => ({ insights: [] }),
-      })
+      ;(global.fetch as any).mockResolvedValue(jsonResponse({ insights: [] }))
 
       await robotoff.insights({
         barcode: "123",
@@ -153,24 +133,21 @@ describe("Robotoff API", () => {
         annotated: false,
       })
 
-      const expectedUrl = expect.stringContaining("barcode=123")
-      expect(global.fetch).toHaveBeenCalledWith(expectedUrl, { credentials: "include" })
+      expect(lastRequest().url).toContain("barcode=123")
+      expect(lastRequestOptions()).toEqual({ credentials: "include" })
     })
 
     it("should handle comma-separated parameters correctly", async () => {
-      ;(global.fetch as any).mockResolvedValue({
-        ok: true,
-        json: async () => ({ insights: [] }),
-      })
+      ;(global.fetch as any).mockResolvedValue(jsonResponse({ insights: [] }))
 
       await robotoff.insights({
         insight_types: "nutrient_extraction,ingredient_spellcheck",
       })
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("insight_types=nutrient_extraction%2Cingredient_spellcheck"),
-        { credentials: "include" }
+      expect(lastRequest().url).toContain(
+        "insight_types=nutrient_extraction%2Cingredient_spellcheck"
       )
+      expect(lastRequestOptions()).toEqual({ credentials: "include" })
     })
   })
 
@@ -184,73 +161,46 @@ describe("Robotoff API", () => {
         ],
       }
 
-      ;(global.fetch as any).mockResolvedValue({
-        ok: true,
-        json: async () => mockResponse,
-      })
+      ;(global.fetch as any).mockResolvedValue(jsonResponse(mockResponse))
 
       const result = await robotoff.fetchRobotoffContributionMessageInsights({
         barcode: "123",
       })
 
-      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("annotated=false"), {
-        credentials: "include",
-      })
-      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("insight_types="), {
-        credentials: "include",
-      })
+      expect(lastRequest().url).toContain("annotated=false")
+      expect(lastRequest().url).toContain("insight_types=")
+      expect(lastRequestOptions()).toEqual({ credentials: "include" })
       expect(result).toEqual(mockResponse.insights)
     })
 
     it("should override annotated parameter", async () => {
-      ;(global.fetch as any).mockResolvedValue({
-        ok: true,
-        json: async () => ({ insights: [] }),
-      })
+      ;(global.fetch as any).mockResolvedValue(jsonResponse({ insights: [] }))
 
       await robotoff.fetchRobotoffContributionMessageInsights({
         annotated: true, // Should be overridden to false
       })
 
-      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("annotated=false"), {
-        credentials: "include",
-      })
+      expect(lastRequest().url).toContain("annotated=false")
+      expect(lastRequestOptions()).toEqual({ credentials: "include" })
     })
   })
 
   describe("annotation methods", () => {
     describe("annotateQuestion", () => {
       it("should annotate question with correct parameters", async () => {
-        const mockRobotoff = {
-          annotate: vi.fn().mockResolvedValue({ status: "saved" }),
-        }
-
-        // Mock the Robotoff constructor
-        const { Robotoff } = await import("@openfoodfacts/openfoodfacts-nodejs")
-        ;(Robotoff as any).mockImplementation(function () {
-          return mockRobotoff
-        })
-
         await robotoff.annotateQuestion("insight-123", AnnotationAnswer.ACCEPT)
 
-        expect(mockRobotoff.annotate).toHaveBeenCalledWith({
-          insight_id: "insight-123",
-          annotation: AnnotationAnswer.ACCEPT,
-        })
+        expect(lastRequest().url).toBe(
+          "https://robotoff.openfoodfacts.org/api/v1/insights/annotate"
+        )
+        expect(lastRequest().method).toBe("POST")
+        expect(lastRequestOptions()).toEqual({ credentials: "include" })
+        await expect(lastRequest().text()).resolves.toBe("insight_id=insight-123&annotation=1")
       })
     })
 
     describe("annotateNutrients", () => {
       it("should annotate nutrients with data", async () => {
-        const mockRobotoff = {
-          annotate: vi.fn().mockResolvedValue({ status: "saved" }),
-        }
-
-        const { Robotoff } = await import("@openfoodfacts/openfoodfacts-nodejs")
-        ;(Robotoff as any).mockImplementation(function () {
-          return mockRobotoff
-        })
-
         const nutrientData = {
           serving_size: null,
           nutrients: { energy: { value: "100", unit: "kJ" } },
@@ -258,72 +208,34 @@ describe("Robotoff API", () => {
         }
         await robotoff.annotateNutrients("insight-123", AnnotationAnswer.ACCEPT, nutrientData)
 
-        expect(mockRobotoff.annotate).toHaveBeenCalledWith({
-          insight_id: "insight-123",
-          annotation: AnnotationAnswer.ACCEPT,
-          data: nutrientData,
-        })
+        await expect(lastRequest().text()).resolves.toBe(
+          `insight_id=insight-123&annotation=1&data=${encodeURIComponent(JSON.stringify(nutrientData))}`
+        )
       })
     })
 
     describe("annotateIngredientSpellcheck", () => {
       it("should annotate ingredient spellcheck with correction", async () => {
-        const mockRobotoff = {
-          annotate: vi.fn().mockResolvedValue({ status: "saved" }),
-        }
-
-        const { Robotoff } = await import("@openfoodfacts/openfoodfacts-nodejs")
-        ;(Robotoff as any).mockImplementation(function () {
-          return mockRobotoff
-        })
-
         await robotoff.annotateIngredientSpellcheck(
           "insight-123",
           AnnotationAnswer.ACCEPT,
           "corrected ingredient"
         )
 
-        expect(mockRobotoff.annotate).toHaveBeenCalledWith({
-          insight_id: "insight-123",
-          annotation: AnnotationAnswer.ACCEPT,
-          data: { annotation: "corrected ingredient" },
-        })
+        await expect(lastRequest().text()).resolves.toBe(
+          "insight_id=insight-123&annotation=1&data=%7B%22annotation%22%3A%22corrected+ingredient%22%7D"
+        )
       })
 
       it("should handle missing correction", async () => {
-        const mockRobotoff = {
-          annotate: vi.fn().mockResolvedValue({ status: "saved" }),
-        }
-
-        const { Robotoff } = await import("@openfoodfacts/openfoodfacts-nodejs")
-        ;(Robotoff as any).mockImplementation(function () {
-          return mockRobotoff
-        })
-
         await robotoff.annotateIngredientSpellcheck("insight-123", AnnotationAnswer.REFUSE)
 
-        expect(mockRobotoff.annotate).toHaveBeenCalledWith({
-          insight_id: "insight-123",
-          annotation: AnnotationAnswer.REFUSE,
-        })
-
-        expect(mockRobotoff.annotate).not.toHaveBeenCalledWith(
-          expect.objectContaining({ data: { annotation: "" } })
-        )
+        await expect(lastRequest().text()).resolves.toBe("insight_id=insight-123&annotation=0")
       })
     })
 
     describe("annotateIngredientDetection", () => {
       it("should annotate ingredient detection with data", async () => {
-        const mockRobotoff = {
-          annotate: vi.fn().mockResolvedValue({ status: "saved" }),
-        }
-
-        const { Robotoff } = await import("@openfoodfacts/openfoodfacts-nodejs")
-        ;(Robotoff as any).mockImplementation(function () {
-          return mockRobotoff
-        })
-
         const detectionData = {
           annotation: "salt, sugar",
           bounding_box: [0, 0, 1, 1] as [number, number, number, number],
@@ -335,11 +247,9 @@ describe("Robotoff API", () => {
           detectionData
         )
 
-        expect(mockRobotoff.annotate).toHaveBeenCalledWith({
-          insight_id: "insight-123",
-          annotation: AnnotationAnswer.ACCEPT,
-          data: detectionData,
-        })
+        await expect(lastRequest().text()).resolves.toBe(
+          `insight_id=insight-123&annotation=1&data=${encodeURIComponent(JSON.stringify(detectionData)).replaceAll("%20", "+")}`
+        )
       })
     })
   })
@@ -355,13 +265,12 @@ describe("Robotoff API", () => {
 
       const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {})
 
-      const result = await robotoff.annotate("test=data")
+      const result = await robotoff.annotateQuestion("insight-123", AnnotationAnswer.ACCEPT)
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Annotated :",
-        "https://robotoff.openfoodfacts.org/api/v1/insights/annotate",
-        "test=data"
-      )
+      expect(consoleSpy).toHaveBeenCalledWith("Annotated :", {
+        insight_id: "insight-123",
+        annotation: AnnotationAnswer.ACCEPT,
+      })
       expect(result).toBeUndefined()
       expect(global.fetch).not.toHaveBeenCalled()
     })
@@ -375,10 +284,7 @@ describe("Robotoff API", () => {
     })
 
     it("should handle malformed API responses", async () => {
-      ;(global.fetch as any).mockResolvedValue({
-        ok: true,
-        json: async () => null,
-      })
+      ;(global.fetch as any).mockResolvedValue(jsonResponse(null))
 
       const result = await robotoff.questionsByProductCode("123")
       expect(result).toBeNull()

--- a/web-components/src/api/robotoff.test.ts
+++ b/web-components/src/api/robotoff.test.ts
@@ -82,14 +82,10 @@ describe("Robotoff API", () => {
 
       await robotoff.questionsByProductCode("123", {
         count: 10,
-        page: 2,
-        insight_types: ["ingredient"],
+        insight_types: "ingredient",
       })
 
       expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("count=10"), {
-        credentials: "include",
-      })
-      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("page=2"), {
         credentials: "include",
       })
       expect(global.fetch).toHaveBeenCalledWith(
@@ -152,7 +148,7 @@ describe("Robotoff API", () => {
 
       await robotoff.insights({
         barcode: "123",
-        insight_types: ["nutrient_extraction"],
+        insight_types: "nutrient_extraction",
         count: 25,
         annotated: false,
       })
@@ -161,18 +157,18 @@ describe("Robotoff API", () => {
       expect(global.fetch).toHaveBeenCalledWith(expectedUrl, { credentials: "include" })
     })
 
-    it("should handle array parameters correctly", async () => {
+    it("should handle comma-separated parameters correctly", async () => {
       ;(global.fetch as any).mockResolvedValue({
         ok: true,
         json: async () => ({ insights: [] }),
       })
 
       await robotoff.insights({
-        insight_types: ["nutrient_extraction", "ingredient_spellcheck"],
+        insight_types: "nutrient_extraction,ingredient_spellcheck",
       })
 
       expect(global.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("insight_types=nutrient_extraction,ingredient_spellcheck"),
+        expect.stringContaining("insight_types=nutrient_extraction%2Cingredient_spellcheck"),
         { credentials: "include" }
       )
     })
@@ -255,7 +251,11 @@ describe("Robotoff API", () => {
           return mockRobotoff
         })
 
-        const nutrientData = { nutrient: "energy", value: "100", unit: "kJ" }
+        const nutrientData = {
+          serving_size: null,
+          nutrients: { energy: { value: "100", unit: "kJ" } },
+          nutrition_data_per: "100g",
+        }
         await robotoff.annotateNutrients("insight-123", AnnotationAnswer.ACCEPT, nutrientData)
 
         expect(mockRobotoff.annotate).toHaveBeenCalledWith({
@@ -324,7 +324,11 @@ describe("Robotoff API", () => {
           return mockRobotoff
         })
 
-        const detectionData = { ingredients: ["salt", "sugar"] }
+        const detectionData = {
+          annotation: "salt, sugar",
+          bounding_box: [0, 0, 1, 1] as [number, number, number, number],
+          rotation: 0,
+        }
         await robotoff.annotateIngredientDetection(
           "insight-123",
           AnnotationAnswer.ACCEPT,

--- a/web-components/src/api/robotoff.test.ts
+++ b/web-components/src/api/robotoff.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import robotoff from "../api/robotoff"
 import { AnnotationAnswer } from "../types/robotoff"
+import { robotoffConfiguration } from "../signals/robotoff"
 
 // Mock dependencies
 vi.mock("../signals/robotoff", () => ({
@@ -19,6 +20,16 @@ vi.mock("../signals/app", () => ({
   },
 }))
 
+const defaultRobotoffApiUrl = "https://robotoff.openfoodfacts.org/api/v1"
+
+const setRobotoffConfiguration = (apiUrl = defaultRobotoffApiUrl, dryRun = false) => {
+  ;(robotoffConfiguration.getItem as any).mockImplementation((key: string) => {
+    if (key === "apiUrl") return apiUrl
+    if (key === "dryRun") return dryRun
+    return null
+  })
+}
+
 const jsonResponse = (body: unknown) =>
   new Response(JSON.stringify(body), {
     status: 200,
@@ -32,6 +43,7 @@ describe("Robotoff API", () => {
   beforeEach(() => {
     global.fetch = vi.fn().mockResolvedValue(jsonResponse({ status: "saved" }))
     vi.clearAllMocks()
+    setRobotoffConfiguration()
   })
 
   describe("questionsByProductCode", () => {
@@ -121,6 +133,27 @@ describe("Robotoff API", () => {
       expect(lastRequest().url).toBe("https://robotoff.openfoodfacts.org/api/v1/insights")
       expect(lastRequestOptions()).toEqual({ credentials: "include" })
       expect(result).toEqual(mockInsights)
+    })
+
+    it("should preserve a configured API path prefix", async () => {
+      setRobotoffConfiguration("https://proxy.example/robotoff/api/v1")
+      ;(global.fetch as any).mockResolvedValue(jsonResponse({ insights: [] }))
+
+      await robotoff.insights()
+
+      expect(lastRequest().url).toBe("https://proxy.example/robotoff/api/v1/insights")
+    })
+
+    it("should resolve relative configured API paths", async () => {
+      const apiPath = "/proxy/robotoff/api/v1"
+      setRobotoffConfiguration(apiPath)
+      ;(global.fetch as any).mockResolvedValue(jsonResponse({ insights: [] }))
+
+      await robotoff.insights()
+
+      expect(lastRequest().url).toBe(
+        new URL(`${apiPath}/insights`, window.location.href).toString()
+      )
     })
 
     it("should handle request parameters", async () => {
@@ -256,12 +289,7 @@ describe("Robotoff API", () => {
 
   describe("dry run mode", () => {
     it("should log instead of making request in dry run mode", async () => {
-      const { robotoffConfiguration } = await import("../signals/robotoff")
-      ;(robotoffConfiguration.getItem as any).mockImplementation((key: string) => {
-        if (key === "apiUrl") return "https://robotoff.openfoodfacts.org/api/v1"
-        if (key === "dryRun") return true
-        return null
-      })
+      setRobotoffConfiguration(defaultRobotoffApiUrl, true)
 
       const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {})
 

--- a/web-components/src/api/robotoff.ts
+++ b/web-components/src/api/robotoff.ts
@@ -61,7 +61,7 @@ const annotate = (formBody: string) => {
  */
 const robotoff = {
   annotate,
-  annotateQuestion(insightId: string, annotation: AnnotationAnswer) {
+  annotateQuestion(insightId: string, annotation: AnnotationAnswer): Promise<unknown> {
     const robotoff = createRobotoff(fetch)
     return robotoff.annotate({ insight_id: insightId, annotation: annotation })
   },
@@ -69,7 +69,7 @@ const robotoff = {
     insightId: string,
     annotation: AnnotationAnswer,
     data?: NutrientsAnnotationData
-  ) {
+  ): Promise<unknown> {
     const newLocal = createRobotoff(fetch)
     return newLocal.annotate({ insight_id: insightId, annotation: annotation, data: data })
   },
@@ -85,7 +85,7 @@ const robotoff = {
     insightId: string,
     annotation: AnnotationAnswer,
     correction?: string
-  ) {
+  ): Promise<unknown> {
     return createRobotoff(fetch).annotate({
       insight_id: insightId,
       annotation: annotation,
@@ -103,7 +103,7 @@ const robotoff = {
     insightId: string,
     annotation: AnnotationAnswer,
     data?: IngredientDetectionAnnotationData
-  ) {
+  ): Promise<unknown> {
     return createRobotoff(fetch).annotate({
       insight_id: insightId,
       annotation: annotation,

--- a/web-components/src/api/robotoff.ts
+++ b/web-components/src/api/robotoff.ts
@@ -168,7 +168,7 @@ const robotoff = {
         InsightType.nutrient_extraction,
         InsightType.ingredient_spellcheck,
         InsightType.ingredient_detection,
-      ],
+      ].join(","),
     })
     return result.insights
   },

--- a/web-components/src/api/robotoff.ts
+++ b/web-components/src/api/robotoff.ts
@@ -1,4 +1,3 @@
-import { addParamsToUrl } from "../utils"
 import {
   type QuestionRequestParams,
   type QuestionsResponse,
@@ -15,7 +14,7 @@ import {
 import { robotoffConfiguration } from "../signals/robotoff"
 import { languageCode } from "../signals/app"
 
-import { Robotoff } from "@openfoodfacts/openfoodfacts-nodejs"
+import { Robotoff, type RobotoffAnnotateBody } from "@openfoodfacts/openfoodfacts-nodejs"
 
 function createRobotoff(fetch: typeof window.fetch) {
   // ensure that any user account credentials get used in Robotoff
@@ -28,50 +27,38 @@ function createRobotoff(fetch: typeof window.fetch) {
 }
 
 /**
- * Get the API URL for a given path with the current configuration
- */
-const getApiUrl = (path: string) => {
-  return `${robotoffConfiguration.getItem("apiUrl")}${path}`
-}
-
-/**
  * Annotate an insight
- * @param formBody
- * @returns {Promise<Response>}
+ * @param body
  */
-const annotate = (formBody: string) => {
-  const apiUrl = getApiUrl("/insights/annotate")
+const annotate = async (body: RobotoffAnnotateBody): Promise<unknown> => {
   if (robotoffConfiguration.getItem("dryRun")) {
-    console.log("Annotated :", apiUrl, formBody)
-    return
-  } else {
-    return fetch(apiUrl, {
-      method: "POST",
-      body: formBody,
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      credentials: "include",
-    })
+    console.log("Annotated :", body)
+    return undefined
   }
+
+  const result = (await createRobotoff(fetch).annotate(body)) as unknown as {
+    data?: unknown
+    error?: unknown
+  }
+  if (result.error) {
+    throw result.error
+  }
+  return result.data
 }
 
 /**
  * Robotoff API
  */
 const robotoff = {
-  annotate,
   annotateQuestion(insightId: string, annotation: AnnotationAnswer): Promise<unknown> {
-    const robotoff = createRobotoff(fetch)
-    return robotoff.annotate({ insight_id: insightId, annotation: annotation })
+    return annotate({ insight_id: insightId, annotation: annotation })
   },
   annotateNutrients(
     insightId: string,
     annotation: AnnotationAnswer,
     data?: NutrientsAnnotationData
   ): Promise<unknown> {
-    const newLocal = createRobotoff(fetch)
-    return newLocal.annotate({ insight_id: insightId, annotation: annotation, data: data })
+    return annotate({ insight_id: insightId, annotation: annotation, data: data })
   },
 
   /**
@@ -86,7 +73,7 @@ const robotoff = {
     annotation: AnnotationAnswer,
     correction?: string
   ): Promise<unknown> {
-    return createRobotoff(fetch).annotate({
+    return annotate({
       insight_id: insightId,
       annotation: annotation,
       ...(correction ? { data: { annotation: correction } } : {}),
@@ -104,7 +91,7 @@ const robotoff = {
     annotation: AnnotationAnswer,
     data?: IngredientDetectionAnnotationData
   ): Promise<unknown> {
-    return createRobotoff(fetch).annotate({
+    return annotate({
       insight_id: insightId,
       annotation: annotation,
       ...(data ? { data: data } : {}),
@@ -121,15 +108,14 @@ const robotoff = {
     code: string,
     questionRequestParams: QuestionRequestParams = {}
   ): Promise<QuestionsResponse> {
-    if (!questionRequestParams.lang) {
-      questionRequestParams.lang = languageCode.get()
+    const result = (await createRobotoff(fetch).questionsByProductCode(code as unknown as number, {
+      ...questionRequestParams,
+      lang: questionRequestParams.lang ?? languageCode.get(),
+    })) as unknown as { data?: QuestionsResponse; error?: unknown }
+    if (result.error) {
+      throw result.error
     }
-    const apiUrl = getApiUrl(`/questions/${code}`)
-    const url = addParamsToUrl(apiUrl, questionRequestParams)
-    // Note: we need credentials to be sure to have all questions
-    const response = await fetch(url, { credentials: "include" })
-    const result: QuestionsResponse = await response.json()
-    return result
+    return result.data as QuestionsResponse
   },
 
   /**
@@ -141,12 +127,14 @@ const robotoff = {
   async insights<
     T extends NutrientsInsight | IngredientSpellcheckInsight | IngredientDetectionInsight,
   >(requestParams: InsightsRequestParams = {}): Promise<InsightsResponse<T>> {
-    const apiUrl = getApiUrl("/insights")
-    const url = addParamsToUrl(apiUrl, requestParams)
-    // Note: we need credentials to be sure to have all insights
-    const response = await fetch(url, { credentials: "include" })
-    const result: InsightsResponse<T> = await response.json()
-    return result
+    const result = (await createRobotoff(fetch).insights(requestParams as never)) as unknown as {
+      data?: InsightsResponse<T>
+      error?: unknown
+    }
+    if (result.error) {
+      throw result.error
+    }
+    return result.data as InsightsResponse<T>
   },
 
   /**

--- a/web-components/src/api/robotoff.ts
+++ b/web-components/src/api/robotoff.ts
@@ -14,16 +14,58 @@ import {
 import { robotoffConfiguration } from "../signals/robotoff"
 import { languageCode } from "../signals/app"
 
-import { Robotoff, type RobotoffAnnotateBody } from "@openfoodfacts/openfoodfacts-nodejs"
+import {
+  Robotoff,
+  type RobotoffAnnotateBody,
+  type RobotoffInsightQuery as SDKRobotoffInsightQuery,
+} from "@openfoodfacts/openfoodfacts-nodejs"
+
+const ROBOTOFF_API_PATH = "/api/v1"
 
 function createRobotoff(fetch: typeof window.fetch) {
+  const configuredBaseUrl = new URL(
+    robotoffConfiguration.getItem("apiUrl") as string,
+    window.location.href
+  )
+  const configuredBasePath = configuredBaseUrl.pathname.replace(/\/+$/, "")
+
   // ensure that any user account credentials get used in Robotoff
   const fetchWithCredentials: typeof window.fetch = (url, options) => {
-    return fetch(url, { ...options, credentials: "include" })
+    const requestUrl = new URL(url instanceof Request ? url.url : url.toString())
+    const requestPath = requestUrl.pathname
+    if (
+      requestUrl.origin === configuredBaseUrl.origin &&
+      (requestPath === ROBOTOFF_API_PATH || requestPath.startsWith(`${ROBOTOFF_API_PATH}/`))
+    ) {
+      requestUrl.pathname = configuredBasePath + requestPath.slice(ROBOTOFF_API_PATH.length)
+    }
+    const request =
+      url instanceof Request
+        ? new Request(requestUrl, {
+            method: url.method,
+            headers: url.headers,
+            ...(url.method === "GET" || url.method === "HEAD"
+              ? {}
+              : { body: url.body, duplex: "half" as const }),
+          })
+        : requestUrl
+    return fetch(request, { ...options, credentials: "include" })
   }
   return new Robotoff(fetchWithCredentials, {
-    baseUrl: robotoffConfiguration.getItem("apiUrl") as string,
+    // The SDK always normalizes its base URL to /api/v1. The fetch adapter above
+    // restores the configured path prefix after that normalization.
+    baseUrl: new URL(ROBOTOFF_API_PATH, configuredBaseUrl.origin).toString(),
   })
+}
+
+const toRobotoffInsightQuery = (
+  requestParams: InsightsRequestParams
+): NonNullable<SDKRobotoffInsightQuery> => {
+  const { barcode, ...query } = requestParams
+  return {
+    ...query,
+    ...(barcode === undefined ? {} : { barcode: Number(barcode) }),
+  }
 }
 
 /**
@@ -127,7 +169,9 @@ const robotoff = {
   async insights<
     T extends NutrientsInsight | IngredientSpellcheckInsight | IngredientDetectionInsight,
   >(requestParams: InsightsRequestParams = {}): Promise<InsightsResponse<T>> {
-    const result = (await createRobotoff(fetch).insights(requestParams as never)) as unknown as {
+    const result = (await createRobotoff(fetch).insights(
+      toRobotoffInsightQuery(requestParams)
+    )) as unknown as {
       data?: InsightsResponse<T>
       error?: unknown
     }

--- a/web-components/src/components/robotoff-contribution-message/robotoff-contribution-message.ts
+++ b/web-components/src/components/robotoff-contribution-message/robotoff-contribution-message.ts
@@ -148,7 +148,7 @@ export class RobotoffContributionMessage extends LanguageCodesMixin(SignalWatche
           ? [
               robotoff.fetchRobotoffContributionMessageInsights({
                 barcode: productCode,
-                lc: this._languageCodes,
+                lc: this._languageCodes.join(","),
               }),
             ]
           : []),

--- a/web-components/src/components/robotoff-ingredient-detection/robotoff-ingredient-detection.ts
+++ b/web-components/src/components/robotoff-ingredient-detection/robotoff-ingredient-detection.ts
@@ -131,7 +131,7 @@ export class RobotoffIngredientDetection extends DisplayProductLinkMixin(
         count,
         page,
         // use _languageCodes instead of languageCodes to get fallback language
-        lc: this._languageCodes,
+        lc: this._languageCodes.join(","),
       })
       this.insightIds = response.map((insight) => insight.id)
       this.dispatchIngredientDetectionStateEvent({

--- a/web-components/src/components/robotoff-ingredient-spellcheck/robotoff-ingredient-spellcheck.ts
+++ b/web-components/src/components/robotoff-ingredient-spellcheck/robotoff-ingredient-spellcheck.ts
@@ -178,7 +178,7 @@ export class RobotoffIngredientSpellcheck extends DisplayProductLinkMixin(
     }
     const result = await fetchProduct<ImageIngredientsProductType>(insight.barcode, {
       lc: insight.data.lang,
-      fields: [ProductFields.IMAGE_INGREDIENTS_URL, ProductFields.PRODUCT_NAME],
+      fields: [ProductFields.IMAGE_INGREDIENTS_URL, ProductFields.PRODUCT_NAME].join(","),
     })
 
     this.productData = {
@@ -199,7 +199,7 @@ export class RobotoffIngredientSpellcheck extends DisplayProductLinkMixin(
         state: EventState.LOADING,
       })
       const insights = await fetchSpellcheckInsights(productCode ? productCode : undefined, {
-        lc: this._languageCodes,
+        lc: this._languageCodes.join(","),
       })
       this._insightIds = insights
         // Currently we filter by lang here but we should do it in the API when is available

--- a/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
+++ b/web-components/src/components/robotoff-nutrient-extraction/robotoff-nutrient-extraction.ts
@@ -147,7 +147,7 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
       this.emitNutrientEvent(EventState.LOADING)
       const [insights] = await Promise.all([
         fetchNutrientInsights(productCode, {
-          lc: this._languageCodes,
+          lc: this._languageCodes.join(","),
         }),
         fetchNutrientsTaxonomies(),
         fetchNutrientsOrderByCountryCode(this._countryCode),
@@ -182,7 +182,7 @@ export class RobotoffNutrientExtraction extends DisplayProductLinkMixin(
   async getProductNutriments(productCode: string) {
     this.nutrimentsData = undefined
     const result = await fetchProduct<NutrimentsProductType>(productCode, {
-      fields: [ProductFields.NUTRIMENTS],
+      fields: ProductFields.NUTRIMENTS,
       lc: languageCode.get(),
     })
     this.nutrimentsData = result.product

--- a/web-components/src/signals/nutrient-extraction.ts
+++ b/web-components/src/signals/nutrient-extraction.ts
@@ -66,7 +66,9 @@ export const fetchNutrientInsights = async (
  * Annotate an insight with data
  * @param data
  */
-export const annotateNutrientsWithData = async (annotation: InsightAnnotationAnswer) => {
+export const annotateNutrientsWithData = async (
+  annotation: InsightAnnotationAnswer
+): Promise<unknown> => {
   const servingSize = annotation.data["serving_size"]?.value ?? null
   // Clone the nutrients object to avoid mutating the original annotation.data
   const clonedData = { ...annotation.data }
@@ -90,6 +92,6 @@ export const annotateNutrientsWithData = async (annotation: InsightAnnotationAns
 export const annotateNutrientWithoutData = async (
   insightId: string,
   annotation: AnnotationAnswer
-) => {
+): Promise<unknown> => {
   return await robotoff.annotateNutrients(insightId, annotation)
 }

--- a/web-components/src/types/openfoodfacts.ts
+++ b/web-components/src/types/openfoodfacts.ts
@@ -1,6 +1,8 @@
+import type { SearchQueryV2 } from "@openfoodfacts/openfoodfacts-nodejs"
+
 export type RequestProductParams = {
-  lc: string
-  fields: string[]
+  lc?: string
+  fields: NonNullable<NonNullable<SearchQueryV2>["fields"]>
 }
 
 // type for the response of the product API
@@ -26,9 +28,10 @@ export type NutrimentsProductType = {
   serving_size: string
 }
 
-export type NutrientsParams = {
+export type NutrientsParams = Partial<{
   cc: string
-}
+  lc: string
+}>
 
 export interface NutrientOrderRequest {
   name: string

--- a/web-components/src/types/robotoff.ts
+++ b/web-components/src/types/robotoff.ts
@@ -1,19 +1,16 @@
+import type { Robotoff, RobotoffAnnotateBody } from "@openfoodfacts/openfoodfacts-nodejs"
+
 export type RobotoffConfigurationOptions = {
   apiUrl: string
   dryRun: boolean
   imgUrl: string
 }
 
-export type QuestionRequestParams = Partial<{
-  insight_types: string
-  brand_filter: string
-  value_tag: string
-  country_filter: string
-  sort_by_popularity: boolean
-  campaign: string
-  predictor: string
-  lang: string
-}>
+type RobotoffClient = InstanceType<typeof Robotoff>
+
+export type QuestionRequestParams = NonNullable<
+  Parameters<RobotoffClient["questionsByProductCode"]>[1]
+>
 
 export type Question = {
   barcode: string
@@ -65,20 +62,20 @@ export enum InsightType {
 }
 
 export type InsightsRequestParams = Partial<{
-  lc: string[]
-  insight_types: string | string[]
+  insight_types: string
   barcode: string
   annotated: boolean
   annotation: number
   value_tag: string
   brands: string
   countries: string
-  server_type: string
+  server_type: "off" | "obf" | "opff" | "opf" | "off_pro"
   predictor: string
-  order_by: string
+  order_by: "confidence" | "random" | "popularity"
   count: number
   page: number
   campaigns: string
+  lc: string
 }>
 
 export type NutrientInsightDatum = {
@@ -193,7 +190,9 @@ export type NutrientAnotationFormData = {
   unit: string | null
 }
 
-export type NutrientsAnnotationData = {
+export type RobotoffAnnotationData = NonNullable<RobotoffAnnotateBody["data"]>
+
+export type NutrientsAnnotationData = RobotoffAnnotationData & {
   serving_size: string | null
   nutrients: Record<string, NutrientAnotationFormData>
   nutrition_data_per: string
@@ -228,7 +227,7 @@ export type IngredientPrediction = {
 }
 export type RobotoffBoundingBox = [number, number, number, number]
 
-export type IngredientDetectionAnnotationData = {
+export type IngredientDetectionAnnotationData = RobotoffAnnotationData & {
   annotation: string
   bounding_box: RobotoffBoundingBox
   rotation: number

--- a/web-components/src/types/robotoff.ts
+++ b/web-components/src/types/robotoff.ts
@@ -1,4 +1,8 @@
-import type { Robotoff, RobotoffAnnotateBody } from "@openfoodfacts/openfoodfacts-nodejs"
+import type {
+  Robotoff,
+  RobotoffAnnotateBody,
+  RobotoffInsightQuery,
+} from "@openfoodfacts/openfoodfacts-nodejs"
 
 export type RobotoffConfigurationOptions = {
   apiUrl: string
@@ -61,22 +65,9 @@ export enum InsightType {
   ingredient_detection = "ingredient_detection",
 }
 
-export type InsightsRequestParams = Partial<{
-  insight_types: string
-  barcode: string
-  annotated: boolean
-  annotation: number
-  value_tag: string
-  brands: string
-  countries: string
-  server_type: "off" | "obf" | "opff" | "opf" | "off_pro"
-  predictor: string
-  order_by: "confidence" | "random" | "popularity"
-  count: number
-  page: number
-  campaigns: string
-  lc: string
-}>
+export type InsightsRequestParams = Omit<NonNullable<RobotoffInsightQuery>, "barcode"> & {
+  barcode?: string
+}
 
 export type NutrientInsightDatum = {
   end: number

--- a/web-components/src/utils/index.test.ts
+++ b/web-components/src/utils/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, beforeEach } from "vitest"
 import {
   paramToString,
   paramsToUrl,

--- a/web-components/src/utils/index.ts
+++ b/web-components/src/utils/index.ts
@@ -100,7 +100,7 @@ export const randomIdGenerator = () => Math.random().toString(36).substring(2, 1
  * @returns () => void - the debounced function
  */
 export const initDebounce = (callback: () => any, debounceTime: number = 500) => {
-  let timeout: number | undefined
+  let timeout: ReturnType<typeof setTimeout> | undefined
   return () => {
     clearTimeout(timeout)
     timeout = setTimeout(() => {

--- a/web-components/src/utils/signals.test.ts
+++ b/web-components/src/utils/signals.test.ts
@@ -6,7 +6,7 @@ describe("Signal Utilities", () => {
     let signalObject: SignalObject<{ key1: string; key2: number; key3: boolean }>
 
     beforeEach(() => {
-      signalObject = new SignalObject({
+      signalObject = new SignalObject<{ key1: string; key2: number; key3: boolean }>({
         key1: "initial",
         key2: 42,
         key3: true,
@@ -120,8 +120,9 @@ describe("Signal Utilities", () => {
           regex: /test/g,
         }
 
-        signalObject.setItem("complex", complexValue)
-        expect(signalObject.getItem("complex")).toEqual(complexValue)
+        const complexSignal = new SignalObject<Record<string, unknown>>({})
+        complexSignal.setItem("complex", complexValue)
+        expect(complexSignal.getItem("complex")).toEqual(complexValue)
       })
 
       it("should trigger reactivity", () => {
@@ -168,7 +169,7 @@ describe("Signal Utilities", () => {
       })
 
       it("should preserve nested object structure", () => {
-        const nestedSignal = new SignalObject({
+        const nestedSignal = new SignalObject<Record<string, unknown>>({
           user: { name: "John", settings: { theme: "dark" } },
         })
 
@@ -358,7 +359,7 @@ describe("Signal Utilities", () => {
         ;(largeObject as any)[`key${i}`] = `value${i}`
       }
 
-      const signal = new SignalObject({ large: null })
+      const signal = new SignalObject<Record<string, unknown>>({ large: null })
 
       expect(() => {
         signal.setItem("large", largeObject)
@@ -368,7 +369,7 @@ describe("Signal Utilities", () => {
     })
 
     it("should handle prototype pollution attempts", () => {
-      const signal = new SignalObject({})
+      const signal = new SignalObject<Record<string, unknown>>({})
 
       // Attempt prototype pollution
       signal.setItem("__proto__", { malicious: true })


### PR DESCRIPTION
## Summary

- Align Open Food Facts and Robotoff types with the Open Food Facts JavaScript SDK/API contract.
- Normalize callers and fixtures to documented comma-separated query values and annotation payloads.
- Refactor the Robotoff wrapper to use the real Open Food Facts SDK for questions, insights, and annotations.
- Add SDK-backed Robotoff tests using mocked transport to verify URLs, credentials, request bodies, and error handling.
- Fix the remaining TypeScript errors.
- Upgrade `@openfoodfacts/openfoodfacts-nodejs` to `2.0.0-alpha.33`.

## Validation

- `npx tsc --noEmit`
- `npm test -- --run` — 151 tests passing
- `npm run lint:eslint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Robotoff API request handling and error propagation.
  - Corrected parameter serialization for languages, insight types, and annotation data.
  - Updated nutrient and ingredient annotation requests to match current API formats.

- **Tests**
  - Expanded API tests to validate real request URLs, parameters, bodies, and responses.
  - Updated annotation test coverage for current request payloads.

- **Maintenance**
  - Updated the Open Food Facts client development dependency.
  - Improved type compatibility across API requests and timer-based utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->