### PR TITLE
feat(product-card): show spinner while image loads

### DIFF
--- a/web-components/src/components/product-card/product-card.test.ts
+++ b/web-components/src/components/product-card/product-card.test.ts
@@ -13,7 +13,7 @@ beforeAll(async () => {
   await import("./product-card")
 })
 
-const createProductCard = (brands: string, quantity: string) => {
+const createProductCard = (brands: string, quantity: string, imageUrl = "") => {
   const element = document.createElement("product-card") as any
 
   element.product = {
@@ -21,7 +21,7 @@ const createProductCard = (brands: string, quantity: string) => {
     product_name: "Test product",
     brands,
     quantity,
-    image_front_small_url: "",
+    image_front_small_url: imageUrl,
     product_type: "food",
   }
 
@@ -54,6 +54,36 @@ describe("product-card", () => {
     await element.updateComplete
 
     expect(getBrandQuantityText(element)).toBe("100 g")
+    element.remove()
+  })
+
+  it("shows a spinner until the product image has loaded", async () => {
+    const element = createProductCard("Brand A", "100 g", "https://example.com/product.jpg")
+    await element.updateComplete
+
+    const image = element.shadowRoot?.querySelector(".product-image") as HTMLImageElement
+    expect(element.shadowRoot?.querySelector(".image-wrapper .loading-ring")).not.toBeNull()
+    expect(image.classList.contains("image-loading")).toBe(true)
+
+    image.dispatchEvent(new Event("load"))
+    await element.updateComplete
+
+    expect(element.shadowRoot?.querySelector(".image-wrapper .loading-ring")).toBeNull()
+    expect(image.classList.contains("image-loading")).toBe(false)
+    element.remove()
+  })
+
+  it("shows the placeholder when the product image fails to load", async () => {
+    const element = createProductCard("Brand A", "100 g", "https://example.com/product.jpg")
+    await element.updateComplete
+
+    const image = element.shadowRoot?.querySelector(".product-image") as HTMLImageElement
+    image.dispatchEvent(new Event("error"))
+    await element.updateComplete
+
+    expect(element.shadowRoot?.querySelector(".image-wrapper .loading-ring")).toBeNull()
+    expect(element.shadowRoot?.querySelector(".product-image")).toBeNull()
+    expect(element.shadowRoot?.querySelector(".placeholder-image")).not.toBeNull()
     element.remove()
   })
 })

--- a/web-components/src/components/product-card/product-card.ts
+++ b/web-components/src/components/product-card/product-card.ts
@@ -88,6 +88,7 @@ export class ProductCard extends LitElement {
       display: flex;
       align-items: center;
       justify-content: center;
+      position: relative;
     }
 
     @media (min-width: 640px) {
@@ -145,6 +146,24 @@ export class ProductCard extends LitElement {
       object-fit: cover;
       border-top-left-radius: 1rem;
       border-bottom-left-radius: 1rem;
+    }
+
+    .image-wrapper {
+      position: relative;
+      height: 100%;
+      width: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .image-wrapper .loading-ring {
+      position: absolute;
+      z-index: 1;
+    }
+
+    .product-image.image-loading {
+      visibility: hidden;
     }
 
     .placeholder-container {
@@ -345,6 +364,12 @@ export class ProductCard extends LitElement {
   @state()
   greenscoreSrc = ""
 
+  @state()
+  private imageLoading = false
+
+  @state()
+  private imageFailed = false
+
   /**
    * Placeholder image URL for products without an image
    */
@@ -368,6 +393,20 @@ export class ProductCard extends LitElement {
   override disconnectedCallback() {
     darkModeListener.unsubscribe(this._darkModeCb)
     super.disconnectedCallback()
+  }
+
+  override willUpdate(changedProperties: Map<string, any>) {
+    super.willUpdate(changedProperties)
+
+    if (changedProperties.has("product")) {
+      const previousProduct = changedProperties.get("product") as Product | undefined
+      const imageUrl = this.product.image_front_small_url
+
+      if (imageUrl !== previousProduct?.image_front_small_url) {
+        this.imageLoading = Boolean(imageUrl)
+        this.imageFailed = false
+      }
+    }
   }
 
   /**
@@ -436,9 +475,19 @@ export class ProductCard extends LitElement {
     }
   }
 
+  private handleImageLoad = () => {
+    this.imageLoading = false
+  }
+
+  private handleImageError = () => {
+    this.imageLoading = false
+    this.imageFailed = true
+  }
+
   override render() {
     const isNavigatingToProduct = this.navigating.to?.params?.barcode === this.product.code
     const hasProductImage = Boolean(this.product.image_front_small_url)
+    const shouldShowProductImage = hasProductImage && !this.imageFailed
     const matchTagInfo = this.getMatchTagInfo()
 
     const brands = this.product.brands?.trim()
@@ -466,20 +515,28 @@ export class ProductCard extends LitElement {
           ? html`<div class="match-tag ${matchTagInfo.cssClass}">${matchTagInfo.text}</div>`
           : nothing}
         <div class="card-content">
-          <div class="image-container">
+          <div class="image-container" aria-busy=${this.imageLoading}>
             ${isNavigatingToProduct
               ? html`
                   <div class="loading-container">
                     <span class="loading-ring"></span>
                   </div>
                 `
-              : hasProductImage
+              : shouldShowProductImage
                 ? html`
-                    <div class="loading-container">
+                    <div class="image-wrapper">
+                      ${this.imageLoading
+                        ? html`<span class="loading-ring" aria-hidden="true"></span>`
+                        : nothing}
                       <img
                         src=${this.product.image_front_small_url}
-                        class="product-image"
+                        class=${classMap({
+                          "product-image": true,
+                          "image-loading": this.imageLoading,
+                        })}
                         alt="Product front"
+                        @load=${this.handleImageLoad}
+                        @error=${this.handleImageError}
                       />
                     </div>
                   `


### PR DESCRIPTION
## Summary
- Show the product-card loading ring while the main product image loads.
- Hide the image until it has loaded to avoid showing partial content.
- Fall back to the placeholder if the image fails.
- Add success and failure coverage.

## Validation
- `npm test -- --run src/components/product-card/product-card.test.ts` (5 passed)
- ESLint passed for the changed files.
- Production build completed; it reports existing unrelated TypeScript diagnostics in other files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product cards now display a loading indicator while product images load.
  * Images are hidden until loading completes to prevent visual glitches.
  * Failed image loads automatically use a placeholder image.

* **Bug Fixes**
  * Updated image state when a product’s image changes, ensuring loading and error handling remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->