### PR TITLE
fix: Update mobile-badges to avoid pinging Google Play and external websites

### DIFF
--- a/web-components/src/components/mobile-badges/mobile-badges.ts
+++ b/web-components/src/components/mobile-badges/mobile-badges.ts
@@ -290,7 +290,17 @@ export class MobileBadges extends LitElement {
    * @returns The path to the badge icon.
    */
   getAndroidAppIconPath(language: string): string {
-    return `https://play.google.com/intl/en_us/badges/static/images/badges/${language}_badge_web_generic.png`
+    let languageName = "English"
+    try {
+      const names = new Intl.DisplayNames(["en"], { type: "language" })
+      const name = names.of(language)
+      if (name) {
+        languageName = name.split(" (")[0].replace(/[^a-zA-Z]/g, "")
+      }
+    } catch (e) {
+      // Ignore
+    }
+    return `playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_${languageName}.svg`
   }
 
   /**
@@ -299,18 +309,17 @@ export class MobileBadges extends LitElement {
    * @returns The path to the badge icon.
    */
   getFDroidAppIconPath(language: string): string {
-    return `https://fdroid.gitlab.io/artwork/badge/get-it-on-${language}.png`
+    return `f-droid/svg/get-it-on-${language}.svg`
   }
 
   /**
    * Generates the path to the Apple App Store badge icon.
-   * Note: This code does not handle the US locale specifically.
    * @param language - The language code.
    * @returns The path to the badge icon.
    */
   getIosAppIconPath(language: string): string {
     if (language === "en") {
-      return "appstore/black/appstore_UK.svg"
+      return "appstore/black/appstore_US.svg"
     }
     return `appstore/black/appstore_${language.toLocaleUpperCase()}.svg`
   }
@@ -366,29 +375,29 @@ export class MobileBadges extends LitElement {
     const badges: Badge[] = [
       {
         href: this.getAndroidAppLink(language),
-        src: this.getAndroidAppIconPath(language),
+        src: getImageUrl(this.getAndroidAppIconPath(language)),
         alt: msg("Get It On Google Play"),
         id: "playstore_badge",
         hide: this.hidePlayStore,
         errorHandler: (e: Event) => {
           const target = e.target as HTMLImageElement
-          target.src = this.getAndroidAppIconPath("en")
+          target.src = getImageUrl(this.getAndroidAppIconPath("en"))
         },
       },
       {
         href: this.fDroidAppLink,
-        src: this.getFDroidAppIconPath(language),
+        src: getImageUrl(this.getFDroidAppIconPath(language)),
         alt: msg("Available on F-Droid"),
         id: "fdroid_badge",
         hide: this.hideFDroid,
         errorHandler: (e: Event) => {
           const target = e.target as HTMLImageElement
-          target.src = this.getFDroidAppIconPath("en")
+          target.src = getImageUrl(this.getFDroidAppIconPath("en"))
         },
       },
       {
         href: this.getAndroidApkAppLink(language),
-        src: getImageUrl("download-apk_en.svg"),
+        src: getImageUrl("app-landing-page/download-apk/download-apk_en.svg"),
         alt: msg("Android APK"),
         id: "apk_badge",
         hide: this.hideApk,

--- a/web-components/src/components/mobile-badges/mobile-badges.ts
+++ b/web-components/src/components/mobile-badges/mobile-badges.ts
@@ -300,7 +300,7 @@ export class MobileBadges extends LitElement {
     } catch (e) {
       // Ignore
     }
-    return `playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_${languageName}.svg`
+    return `https://world.openfoodfacts.org/images/misc/playstore/img/latest/GetItOnGooglePlay_Badge_Web_color_${languageName}.svg`
   }
 
   /**
@@ -309,7 +309,7 @@ export class MobileBadges extends LitElement {
    * @returns The path to the badge icon.
    */
   getFDroidAppIconPath(language: string): string {
-    return `f-droid/svg/get-it-on-${language}.svg`
+    return `https://world.openfoodfacts.org/images/misc/f-droid/svg/get-it-on-${language}.svg`
   }
 
   /**
@@ -319,9 +319,9 @@ export class MobileBadges extends LitElement {
    */
   getIosAppIconPath(language: string): string {
     if (language === "en") {
-      return "appstore/black/appstore_US.svg"
+      return "https://world.openfoodfacts.org/images/misc/appstore/black/appstore_US.svg"
     }
-    return `appstore/black/appstore_${language.toLocaleUpperCase()}.svg`
+    return `https://world.openfoodfacts.org/images/misc/appstore/black/appstore_${language.toLocaleUpperCase()}.svg`
   }
 
   /**
@@ -375,42 +375,42 @@ export class MobileBadges extends LitElement {
     const badges: Badge[] = [
       {
         href: this.getAndroidAppLink(language),
-        src: getImageUrl(this.getAndroidAppIconPath(language)),
+        src: this.getAndroidAppIconPath(language),
         alt: msg("Get It On Google Play"),
         id: "playstore_badge",
         hide: this.hidePlayStore,
         errorHandler: (e: Event) => {
           const target = e.target as HTMLImageElement
-          target.src = getImageUrl(this.getAndroidAppIconPath("en"))
+          target.src = this.getAndroidAppIconPath("en")
         },
       },
       {
         href: this.fDroidAppLink,
-        src: getImageUrl(this.getFDroidAppIconPath(language)),
+        src: this.getFDroidAppIconPath(language),
         alt: msg("Available on F-Droid"),
         id: "fdroid_badge",
         hide: this.hideFDroid,
         errorHandler: (e: Event) => {
           const target = e.target as HTMLImageElement
-          target.src = getImageUrl(this.getFDroidAppIconPath("en"))
+          target.src = this.getFDroidAppIconPath("en")
         },
       },
       {
         href: this.getAndroidApkAppLink(language),
-        src: getImageUrl("app-landing-page/download-apk/download-apk_en.svg"),
+        src: "https://world.openfoodfacts.org/images/misc/app-landing-page/download-apk/download-apk_en.svg",
         alt: msg("Android APK"),
         id: "apk_badge",
         hide: this.hideApk,
       },
       {
         href: this.getIosAppLink(language),
-        src: getImageUrl(this.getIosAppIconPath(language)),
+        src: this.getIosAppIconPath(language),
         alt: msg("Download on the App Store"),
         id: "appstore_badge",
         hide: this.hideAppStore,
         errorHandler: (e: Event) => {
           const target = e.target as HTMLImageElement
-          target.src = getImageUrl(this.getIosAppIconPath("en"))
+          target.src = this.getIosAppIconPath("en")
         },
       },
     ]


### PR DESCRIPTION
### What
- fix: Update mobile-badges.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated mobile app badges to use reliable absolute image URLs.
  * Improved Android badge labels based on the selected language.
  * Corrected the English App Store badge to use the US version.
  * Improved fallback handling when App Store badge images fail to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->