### PR TITLE
feat: show the live fundraiser figures in the donation banner and the news feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A set of web components for Open Food Facts to help build edition interfaces
 
 #### Display elements
 - [Donation Banner](https://openfoodfacts.github.io/openfoodfacts-webcomponents/#donation-banner)
+- [Donation Meter](https://openfoodfacts.github.io/openfoodfacts-webcomponents/#donation-meter)
 - [Mobile Badges](https://openfoodfacts.github.io/openfoodfacts-webcomponents/#mobile-badges)
 - [Barcode Scanner](https://openfoodfacts.github.io/openfoodfacts-webcomponents/#barcode-scanner)
 - [Autocomplete Input](https://openfoodfacts.github.io/openfoodfacts-webcomponents/#autocomplete-input)

--- a/web-components/src/components/donation-banner/donation-banner.stories.ts
+++ b/web-components/src/components/donation-banner/donation-banner.stories.ts
@@ -13,3 +13,10 @@ type Story = StoryObj
 export const Basic: Story = {
   args: {},
 }
+
+export const WithCampaignFigures: Story = {
+  args: {
+    newsUrl:
+      "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json",
+  },
+}

--- a/web-components/src/components/donation-banner/donation-banner.test.ts
+++ b/web-components/src/components/donation-banner/donation-banner.test.ts
@@ -1,0 +1,70 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+beforeAll(async () => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  })
+
+  await import("./donation-banner")
+})
+
+const FEED_URL = "https://example.org/main.json"
+
+const createBanner = async (newsUrl?: string) => {
+  const element = document.createElement("donation-banner") as any
+  if (newsUrl) {
+    element.setAttribute("news-url", newsUrl)
+  }
+  document.body.appendChild(element)
+  await element.updateComplete
+  return element
+}
+
+const donateLink = (element: any) => element.shadowRoot.querySelector("a").getAttribute("href")
+
+const listItems = (element: any) =>
+  Array.from(element.shadowRoot.querySelectorAll("li")).map((item: any) => item.textContent.trim())
+
+const ASK = [
+  "keeping our database open & available to all,",
+  "technical infrastructure (website/mobile app) & a small permanent team",
+  "remain independent of the food industry,",
+  "engage a community of committed citizens,",
+  "support the advancement of public health research.",
+]
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+})
+
+describe("donation-banner", () => {
+  it("shows no meter and no extra tracking without a news feed", async () => {
+    const element = await createBanner()
+
+    expect(element.shadowRoot.querySelector("donation-meter")).toBeNull()
+    expect(donateLink(element)).not.toContain("utm_content")
+  })
+
+  it("shows the meter and marks the donate link when a news feed is given", async () => {
+    const element = await createBanner(FEED_URL)
+
+    const meter = element.shadowRoot.querySelector("donation-meter")
+    expect(meter.getAttribute("url")).toBe(FEED_URL)
+    expect(donateLink(element)).toContain("utm_content=meter")
+  })
+
+  it("keeps the donation ask itself unchanged either way", async () => {
+    const plain = await createBanner()
+    const metered = await createBanner(FEED_URL)
+
+    expect(listItems(plain)).toEqual(ASK)
+    expect(listItems(metered)).toEqual(ASK)
+    expect(plain.shadowRoot.querySelector("button").textContent.trim()).toBe("I SUPPORT")
+    expect(metered.shadowRoot.querySelector("button").textContent.trim()).toBe("I SUPPORT")
+  })
+})

--- a/web-components/src/components/donation-banner/donation-banner.test.ts
+++ b/web-components/src/components/donation-banner/donation-banner.test.ts
@@ -1,4 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { languageCode } from "../../signals/app"
+import { DEFAULT_LANGUAGE_CODE } from "../../constants"
 
 beforeAll(async () => {
   Object.defineProperty(window, "matchMedia", {
@@ -15,10 +17,10 @@ beforeAll(async () => {
 
 const FEED_URL = "https://example.org/main.json"
 
-const createBanner = async (newsUrl?: string) => {
+const createBanner = async (attributes: Record<string, string> = {}) => {
   const element = document.createElement("donation-banner") as any
-  if (newsUrl) {
-    element.setAttribute("news-url", newsUrl)
+  for (const [key, value] of Object.entries(attributes)) {
+    element.setAttribute(key, value)
   }
   document.body.appendChild(element)
   await element.updateComplete
@@ -85,6 +87,7 @@ const ASK = [
 
 beforeEach(() => {
   vi.mocked(global.fetch).mockReset()
+  languageCode.set(DEFAULT_LANGUAGE_CODE)
   document.body.innerHTML = ""
 })
 
@@ -225,11 +228,55 @@ describe("donation-banner", () => {
 
   it("keeps the donation ask itself unchanged either way", async () => {
     const plain = await createBanner()
-    const metered = await createBanner(FEED_URL)
+    const metered = await createBanner({ "news-url": FEED_URL })
 
     expect(listItems(plain)).toEqual(ASK)
     expect(listItems(metered)).toEqual(ASK)
     expect(plain.shadowRoot.querySelector("button").textContent.trim()).toBe("I SUPPORT")
     expect(metered.shadowRoot.querySelector("button").textContent.trim()).toBe("I SUPPORT")
+  })
+
+  it("displays the updated title, hook, financial callout and community image", async () => {
+    const element = await createBanner()
+
+    expect(
+      element.shadowRoot.querySelector(".donation-banner-footer__main-title").textContent.trim()
+    ).toBe("Become an Open Food Facts patron")
+    expect(
+      element.shadowRoot.querySelector(".donation-banner-footer__hook-section p").textContent.trim()
+    ).toBe("We still need €120,000 to finish 2026!")
+    expect(
+      element.shadowRoot
+        .querySelector(".donation-banner-footer__actions-section__financial p")
+        .textContent.trim()
+    ).toBe(
+      "If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!"
+    )
+    expect(element.shadowRoot.querySelector("img.group-image")).not.toBeNull()
+  })
+
+  it("supports custom donate-url attribute", async () => {
+    const element = await createBanner({ "donate-url": "https://example.org/custom-donate" })
+
+    const href = donateLink(element)
+    expect(href).toContain("https://example.org/custom-donate")
+    expect(href).toContain("utm_source=off")
+  })
+
+  it("supports custom donate-link attribute", async () => {
+    const element = await createBanner({ "donate-link": "https://example.org/from-server-link" })
+
+    const href = donateLink(element)
+    expect(href).toContain("https://example.org/from-server-link")
+    expect(href).toContain("utm_source=off")
+  })
+
+  it("localizes the fallback donation link and utm_term for Japanese", async () => {
+    languageCode.set("ja")
+    const element = await createBanner()
+
+    const href = donateLink(element)
+    expect(href).toContain("https://world-ja.openfoodfacts.org/donate-to-open-food-facts")
+    expect(href).toContain("utm_term=ja-text-button")
   })
 })

--- a/web-components/src/components/donation-banner/donation-banner.test.ts
+++ b/web-components/src/components/donation-banner/donation-banner.test.ts
@@ -27,6 +27,51 @@ const createBanner = async (newsUrl?: string) => {
 
 const donateLink = (element: any) => element.shadowRoot.querySelector("a").getAttribute("href")
 
+const meterOf = (element: any) => element.shadowRoot.querySelector("donation-meter")
+
+const meterStates = (element: any) => {
+  const states: string[] = []
+  element.addEventListener("donation-meter-state", (event: any) => states.push(event.detail.state))
+  return states
+}
+
+/** `loading` is announced before the feed answers, so waiting on the link alone proves nothing. */
+const settle = async (element: any, states: string[]) => {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    await element.updateComplete
+    if (states.length > 0 && states.at(-1) !== "loading") {
+      break
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+}
+
+const campaignFeed = (campaign: Record<string, unknown>) => ({
+  news: { donation_campaign: campaign },
+  tagline_feed: { default: { news: [{ id: "donation_campaign" }] } },
+})
+
+const mountMeteredBanner = async () => {
+  const element = document.createElement("donation-banner") as any
+  const states = meterStates(element)
+  element.setAttribute("news-url", FEED_URL)
+  document.body.appendChild(element)
+  await element.updateComplete
+  return { element, states }
+}
+
+const createMeteredBanner = async (body: unknown) => {
+  vi.mocked(global.fetch).mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response)
+
+  const { element, states } = await mountMeteredBanner()
+  await settle(element, states)
+  return element
+}
+
 const listItems = (element: any) =>
   Array.from(element.shadowRoot.querySelectorAll("li")).map((item: any) => item.textContent.trim())
 
@@ -39,6 +84,7 @@ const ASK = [
 ]
 
 beforeEach(() => {
+  vi.mocked(global.fetch).mockReset()
   document.body.innerHTML = ""
 })
 
@@ -50,11 +96,130 @@ describe("donation-banner", () => {
     expect(donateLink(element)).not.toContain("utm_content")
   })
 
-  it("shows the meter and marks the donate link when a news feed is given", async () => {
-    const element = await createBanner(FEED_URL)
+  it("shows the meter and marks the donate link once the feed carries figures", async () => {
+    const element = await createMeteredBanner(
+      campaignFeed({ raised: 44156, goal: 170000, currency: "EUR" })
+    )
 
-    const meter = element.shadowRoot.querySelector("donation-meter")
-    expect(meter.getAttribute("url")).toBe(FEED_URL)
+    expect(meterOf(element).getAttribute("url")).toBe(FEED_URL)
+    expect(meterOf(element).shadowRoot.querySelector(".bar")).not.toBeNull()
+    expect(donateLink(element)).toContain("utm_content=meter")
+  })
+
+  it("leaves the link untagged when the feed carries no figures to show", async () => {
+    const element = await createMeteredBanner(campaignFeed({ raised: 44156, currency: "EUR" }))
+
+    expect(meterOf(element)).not.toBeNull()
+    expect(meterOf(element).shadowRoot.querySelector(".bar")).toBeNull()
+    expect(donateLink(element)).not.toContain("utm_content")
+  })
+
+  it("leaves the link untagged when the feed request fails", async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error("the feed is unreachable"))
+
+    const { element, states } = await mountMeteredBanner()
+    await settle(element, states)
+
+    expect(meterOf(element)).not.toBeNull()
+    expect(meterOf(element).shadowRoot.querySelector(".bar")).toBeNull()
+    expect(donateLink(element)).not.toContain("utm_content")
+  })
+
+  it("drops the tag when the feed is taken away at runtime", async () => {
+    const element = await createMeteredBanner(
+      campaignFeed({ raised: 44156, goal: 170000, currency: "EUR" })
+    )
+    expect(donateLink(element)).toContain("utm_content=meter")
+
+    element.removeAttribute("news-url")
+    await element.updateComplete
+
+    expect(meterOf(element)).toBeNull()
+    expect(donateLink(element)).not.toContain("utm_content")
+  })
+
+  it("does not tag the link while the feed is still in flight", async () => {
+    let answer: (response: Response) => void = () => {}
+    vi.mocked(global.fetch).mockReturnValue(
+      new Promise<Response>((resolve) => {
+        answer = resolve
+      })
+    )
+
+    const { element, states } = await mountMeteredBanner()
+    for (let attempt = 0; attempt < 20 && states.length === 0; attempt++) {
+      await element.updateComplete
+      await new Promise((resolve) => setTimeout(resolve, 5))
+    }
+
+    expect(states).toEqual(["loading"])
+    expect(donateLink(element)).not.toContain("utm_content")
+
+    answer({
+      ok: true,
+      status: 200,
+      json: async () => campaignFeed({ raised: 44156, goal: 170000, currency: "EUR" }),
+    } as Response)
+    await settle(element, states)
+
+    expect(donateLink(element)).toContain("utm_content=meter")
+  })
+
+  it("ignores a late answer from a meter that has already left the page", async () => {
+    const element = await createMeteredBanner(
+      campaignFeed({ raised: 44156, goal: 170000, currency: "EUR" })
+    )
+    const ghost = meterOf(element)
+
+    element.removeAttribute("news-url")
+    await element.updateComplete
+    const states = meterStates(element)
+    element.setAttribute("news-url", "https://example.org/other.json")
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => campaignFeed({ raised: 44156, currency: "EUR" }),
+    } as Response)
+    await settle(element, states)
+
+    expect(meterOf(element)).not.toBe(ghost)
+    expect(ghost.isConnected).toBe(false)
+    expect(donateLink(element)).not.toContain("utm_content")
+
+    ghost.dispatchEvent(
+      new CustomEvent("donation-meter-state", {
+        detail: { state: "has-data" },
+        bubbles: true,
+        composed: true,
+      })
+    )
+    await element.updateComplete
+
+    expect(donateLink(element)).not.toContain("utm_content")
+  })
+
+  it("still tags the link when the feed answers while the banner is off the page", async () => {
+    let answer: (response: Response) => void = () => {}
+    vi.mocked(global.fetch).mockReturnValue(
+      new Promise<Response>((resolve) => {
+        answer = resolve
+      })
+    )
+
+    const { element } = await mountMeteredBanner()
+    element.remove()
+    answer({
+      ok: true,
+      status: 200,
+      json: async () => campaignFeed({ raised: 44156, goal: 170000, currency: "EUR" }),
+    } as Response)
+    await new Promise((resolve) => setTimeout(resolve, 5))
+
+    const states = meterStates(element)
+    document.body.appendChild(element)
+    await settle(element, states)
+
+    expect(meterOf(element).shadowRoot.querySelector(".bar")).not.toBeNull()
     expect(donateLink(element)).toContain("utm_content=meter")
   })
 

--- a/web-components/src/components/donation-banner/donation-banner.test.ts
+++ b/web-components/src/components/donation-banner/donation-banner.test.ts
@@ -271,6 +271,14 @@ describe("donation-banner", () => {
     expect(href).toContain("utm_source=off")
   })
 
+  it("refuses a donate link that is not an http(s) URL", async () => {
+    const element = await createBanner({ "donate-url": "javascript:alert(document.cookie)//" })
+
+    const href = donateLink(element)
+    expect(href.startsWith("javascript:")).toBe(false)
+    expect(href).toContain("https://world.openfoodfacts.org/donate-to-open-food-facts")
+  })
+
   it("localizes the fallback donation link and utm_term for Japanese", async () => {
     languageCode.set("ja")
     const element = await createBanner()

--- a/web-components/src/components/donation-banner/donation-banner.ts
+++ b/web-components/src/components/donation-banner/donation-banner.ts
@@ -41,6 +41,16 @@ export class DonationBanner extends LitElement {
   private meterHasFigures = false
 
   /**
+   * Custom link/url to the donation page.
+   * @type {String}
+   */
+  @property({ type: String, attribute: "donate-url" })
+  donateUrl?: string
+
+  @property({ type: String, attribute: "donate-link" })
+  donateLinkProp?: string
+
+  /**
    * The fundraiser year (next year)
    * @type {String}
    */
@@ -80,12 +90,18 @@ export class DonationBanner extends LitElement {
   }
 
   getLinkWithQueryParams(link: string) {
-    const url = new URL(link)
+    const locale = languageCode.get()
+    const url = new URL(
+      link,
+      typeof window !== "undefined" && window.location?.href
+        ? window.location.href
+        : "https://world.openfoodfacts.org"
+    )
     const params = new URLSearchParams(url.search)
     if (!params.has("utm_source")) params.set("utm_source", "off")
     if (!params.has("utm_medium")) params.set("utm_medium", "web")
     if (!params.has("utm_campaign")) params.set("utm_campaign", `donate-${this.currentYear}-a`)
-    if (!params.has("utm_term")) params.set("utm_term", "en-text-button")
+    if (!params.has("utm_term")) params.set("utm_term", `${locale || "en"}-text-button`)
     // A meter showing nothing leaves the banner identical to the plain one, so
     // crediting the click to a meter that is not there would inflate the count.
     if (this.newsUrl && this.meterHasFigures && !params.has("utm_content"))
@@ -96,8 +112,16 @@ export class DonationBanner extends LitElement {
 
   get donateLink() {
     const locale = languageCode.get()
+    const customLink = this.donateUrl || this.donateLinkProp
+    if (customLink) {
+      return this.getLinkWithQueryParams(customLink)
+    }
     const link =
-      locale in this.links ? this.links[locale as keyof typeof this.links] : this.links.default
+      locale in this.links
+        ? this.links[locale as keyof typeof this.links]
+        : locale && locale !== "en"
+          ? `https://world-${locale}.openfoodfacts.org/donate-to-open-food-facts`
+          : this.links.default
     return this.getLinkWithQueryParams(link)
   }
 
@@ -393,9 +417,7 @@ export class DonationBanner extends LitElement {
       <div class="donation-banner-footer row">
         <div class="donation-banner-footer__left-aside">
           <div class="donation-banner-footer__hook-section">
-            <p>
-              ${msg("Help us inform millions of consumers around the world about what they eat")}
-            </p>
+            <p>${msg("We still need €120,000 to finish 2026!")}</p>
           </div>
           <img
             class="group-image"
@@ -413,7 +435,7 @@ export class DonationBanner extends LitElement {
                 alt="open food facts logo"
               />
               <h3 class="donation-banner-footer__main-title">
-                ${msg(str`Please give to our ${this.currentYear} Fundraiser`)}
+                ${msg("Become an Open Food Facts patron")}
               </h3>
             </div>
             <p style="margin: 0 0 20px; font-size: 14px;">
@@ -445,7 +467,7 @@ export class DonationBanner extends LitElement {
             <div class="donation-banner-footer__actions-section__financial">
               <p style="margin: 0px; line-height: 1.6">
                 ${msg(
-                  "Each donation counts! We appreciate your support in bringing further food transparency in the world."
+                  "If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!"
                 )}
               </p>
             </div>

--- a/web-components/src/components/donation-banner/donation-banner.ts
+++ b/web-components/src/components/donation-banner/donation-banner.ts
@@ -1,7 +1,9 @@
 import { LitElement, html, css, nothing } from "lit"
-import { customElement, property } from "lit/decorators.js"
+import { customElement, property, state } from "lit/decorators.js"
 import { localized, msg, str } from "@lit/localize"
 import { getImageUrl, languageCode } from "../../signals/app"
+import { EventState } from "../../constants"
+import type { BasicStateEventDetail } from "../../types"
 import { classMap } from "lit/directives/class-map.js"
 import { darkModeListener } from "../../utils/dark-mode-listener"
 import "../donation-meter/donation-meter"
@@ -34,6 +36,10 @@ export class DonationBanner extends LitElement {
   @property({ type: String, attribute: "news-url" })
   newsUrl?: string
 
+  /** Whether the meter is showing figures, not merely mounted. */
+  @state()
+  private meterHasFigures = false
+
   /**
    * The fundraiser year (next year)
    * @type {String}
@@ -64,6 +70,15 @@ export class DonationBanner extends LitElement {
     return (new Date().getFullYear() + 1).toString()
   }
 
+  private onMeterState = (event: CustomEvent<BasicStateEventDetail>) => {
+    // A meter removed from the page keeps its in-flight request, and Lit keeps
+    // the listener bound to it, so a late answer must not speak for the banner.
+    if (!(event.target as HTMLElement).isConnected) {
+      return
+    }
+    this.meterHasFigures = event.detail.state === EventState.HAS_DATA
+  }
+
   getLinkWithQueryParams(link: string) {
     const url = new URL(link)
     const params = new URLSearchParams(url.search)
@@ -71,7 +86,10 @@ export class DonationBanner extends LitElement {
     if (!params.has("utm_medium")) params.set("utm_medium", "web")
     if (!params.has("utm_campaign")) params.set("utm_campaign", `donate-${this.currentYear}-a`)
     if (!params.has("utm_term")) params.set("utm_term", "en-text-button")
-    if (this.newsUrl && !params.has("utm_content")) params.set("utm_content", "meter")
+    // A meter showing nothing leaves the banner identical to the plain one, so
+    // crediting the click to a meter that is not there would inflate the count.
+    if (this.newsUrl && this.meterHasFigures && !params.has("utm_content"))
+      params.set("utm_content", "meter")
     url.search = params.toString()
     return url.toString()
   }
@@ -416,7 +434,12 @@ export class DonationBanner extends LitElement {
                 <p>${msg("support the advancement of public health research.")}</p>
               </li>
             </ul>
-            ${this.newsUrl ? html`<donation-meter url=${this.newsUrl}></donation-meter>` : nothing}
+            ${this.newsUrl
+              ? html`<donation-meter
+                  url=${this.newsUrl}
+                  @donation-meter-state="${this.onMeterState}"
+                ></donation-meter>`
+              : nothing}
           </div>
           <div class="donation-banner-footer__actions-section">
             <div class="donation-banner-footer__actions-section__financial">

--- a/web-components/src/components/donation-banner/donation-banner.ts
+++ b/web-components/src/components/donation-banner/donation-banner.ts
@@ -91,12 +91,19 @@ export class DonationBanner extends LitElement {
 
   getLinkWithQueryParams(link: string) {
     const locale = languageCode.get()
-    const url = new URL(
+    let url = new URL(
       link,
       typeof window !== "undefined" && window.location?.href
         ? window.location.href
         : "https://world.openfoodfacts.org"
     )
+    // The link is rendered into an href, which is a script sink, and the page
+    // embedding this element chooses it. `javascript:donate()//` would run in
+    // that page and comment out the parameters appended below, so anything
+    // that is not one of the two web schemes falls back to the donation page.
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      url = new URL(this.links.default)
+    }
     const params = new URLSearchParams(url.search)
     if (!params.has("utm_source")) params.set("utm_source", "off")
     if (!params.has("utm_medium")) params.set("utm_medium", "web")

--- a/web-components/src/components/donation-banner/donation-banner.ts
+++ b/web-components/src/components/donation-banner/donation-banner.ts
@@ -1,9 +1,10 @@
-import { LitElement, html, css } from "lit"
+import { LitElement, html, css, nothing } from "lit"
 import { customElement, property } from "lit/decorators.js"
 import { localized, msg, str } from "@lit/localize"
 import { getImageUrl, languageCode } from "../../signals/app"
 import { classMap } from "lit/directives/class-map.js"
 import { darkModeListener } from "../../utils/dark-mode-listener"
+import "../donation-meter/donation-meter"
 
 /**
  * Donation banner
@@ -25,6 +26,13 @@ export class DonationBanner extends LitElement {
     fr: "https://open-food-facts.assoconnect.com/collect/description/476750-c-faire-un-don-a-open-food-facts",
     default: "https://world.openfoodfacts.org/donate-to-open-food-facts",
   }
+
+  /**
+   * News feed carrying the campaign figures.
+   * @type {String}
+   */
+  @property({ type: String, attribute: "news-url" })
+  newsUrl?: string
 
   /**
    * The fundraiser year (next year)
@@ -63,6 +71,7 @@ export class DonationBanner extends LitElement {
     if (!params.has("utm_medium")) params.set("utm_medium", "web")
     if (!params.has("utm_campaign")) params.set("utm_campaign", `donate-${this.currentYear}-a`)
     if (!params.has("utm_term")) params.set("utm_term", "en-text-button")
+    if (this.newsUrl && !params.has("utm_content")) params.set("utm_content", "meter")
     url.search = params.toString()
     return url.toString()
   }
@@ -407,6 +416,7 @@ export class DonationBanner extends LitElement {
                 <p>${msg("support the advancement of public health research.")}</p>
               </li>
             </ul>
+            ${this.newsUrl ? html`<donation-meter url=${this.newsUrl}></donation-meter>` : nothing}
           </div>
           <div class="donation-banner-footer__actions-section">
             <div class="donation-banner-footer__actions-section__financial">

--- a/web-components/src/components/donation-meter/donation-meter.stories.ts
+++ b/web-components/src/components/donation-meter/donation-meter.stories.ts
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/web-components-vite"
+import { html } from "lit"
+import "./donation-meter"
+
+const meta: Meta = {
+  title: "Components/Donation Meter",
+  component: "donation-meter",
+}
+export default meta
+
+type Story = StoryObj
+
+export const FromTheNewsFeed: Story = {
+  args: {
+    url: "https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json",
+  },
+}
+
+export const Figures: Story = {
+  render: () =>
+    html`<donation-meter
+      .funding=${{ raised: 44156, goal: 170000, currency: "EUR" }}
+    ></donation-meter>`,
+}
+
+export const Funded: Story = {
+  render: () =>
+    html`<donation-meter
+      .funding=${{ raised: 180000, goal: 170000, currency: "EUR" }}
+    ></donation-meter>`,
+}

--- a/web-components/src/components/donation-meter/donation-meter.test.ts
+++ b/web-components/src/components/donation-meter/donation-meter.test.ts
@@ -70,6 +70,23 @@ const text = (element: any) =>
 
 const bar = (element: any) => element.shadowRoot.querySelector(".bar")
 
+const recordStates = (element: any) => {
+  const states: string[] = []
+  element.addEventListener("donation-meter-state", (event: any) => states.push(event.detail.state))
+  return states
+}
+
+/** Waits for the fetch to land: `loading` is announced before the answer is known. */
+const settleState = async (element: any, states: string[]) => {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    await element.updateComplete
+    if (states.length > 0 && states.at(-1) !== "loading") {
+      break
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+}
+
 beforeEach(() => {
   document.body.innerHTML = ""
 })
@@ -201,5 +218,48 @@ describe("donation-meter", () => {
     await element.updateComplete
 
     expect(text(element)).toBe("")
+  })
+
+  it("announces has-data once the figures are on screen", async () => {
+    const element = document.createElement("donation-meter") as any
+    const states = recordStates(element)
+    element.funding = { raised: 44156, goal: 170000, currency: "EUR" }
+    document.body.appendChild(element)
+    await element.updateComplete
+
+    expect(bar(element)).not.toBeNull()
+    expect(states).toEqual(["has-data"])
+
+    element.requestUpdate()
+    await element.updateComplete
+    expect(states).toEqual(["has-data"])
+  })
+
+  it("announces no-data when the figures do not parse", async () => {
+    const element = document.createElement("donation-meter") as any
+    const states = recordStates(element)
+    element.funding = { raised: 44156, goal: 0, currency: "EUR" }
+    document.body.appendChild(element)
+    await element.updateComplete
+
+    expect(bar(element)).toBeNull()
+    expect(states).toEqual(["no-data"])
+  })
+
+  it("announces the drop back to no-data when a live feed stops carrying figures", async () => {
+    const element = await meterFromFeed(feedWith({ raised: 44156, goal: 170000, currency: "EUR" }))
+    expect(bar(element)).not.toBeNull()
+
+    const states = recordStates(element)
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => feedWith({ raised: 44156, currency: "EUR" }),
+    } as Response)
+    element.setAttribute("url", "https://example.org/other.json")
+    await settleState(element, states)
+
+    expect(bar(element)).toBeNull()
+    expect(states).toEqual(["loading", "no-data"])
   })
 })

--- a/web-components/src/components/donation-meter/donation-meter.test.ts
+++ b/web-components/src/components/donation-meter/donation-meter.test.ts
@@ -1,0 +1,205 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import dayjs from "dayjs/esm"
+import { languageCode } from "../../signals/app"
+
+beforeAll(async () => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  })
+
+  await import("./donation-meter")
+})
+
+const FEED_URL = "https://example.org/main.json"
+
+const inDays = (days: number) => dayjs().add(days, "day").format("YYYY-MM-DD HH:mm:ss")
+
+const feedWith = (campaign: Record<string, unknown>) => ({
+  news: {
+    donation_campaign: {
+      translations: { default: { title: "Campaign", message: "Give" } },
+      start_date: inDays(-30),
+      end_date: inDays(150),
+      ...campaign,
+    },
+  },
+  tagline_feed: { default: { news: [{ id: "donation_campaign" }] } },
+})
+
+const meterWithFigures = async (raised: number, goal: number, currency = "EUR") => {
+  const element = document.createElement("donation-meter") as any
+  element.funding = { raised, goal, currency }
+  document.body.appendChild(element)
+  await element.updateComplete
+  return element
+}
+
+const meterFromFeed = async (body: unknown, ok = true) => {
+  vi.mocked(global.fetch).mockResolvedValue({
+    ok,
+    status: ok ? 200 : 404,
+    json: async () => body,
+  } as Response)
+
+  const element = document.createElement("donation-meter") as any
+  element.setAttribute("url", FEED_URL)
+  document.body.appendChild(element)
+
+  for (let attempt = 0; attempt < 20; attempt++) {
+    await element.updateComplete
+    if (element.shadowRoot.querySelector(".bar")) {
+      break
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  return element
+}
+
+const text = (element: any) =>
+  Array.from(element.shadowRoot.childNodes)
+    .filter((node: any) => node.nodeName !== "STYLE")
+    .map((node: any) => node.textContent)
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim()
+
+const bar = (element: any) => element.shadowRoot.querySelector(".bar")
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+})
+
+describe("donation-meter", () => {
+  it("renders the figures, the percentage and the bar", async () => {
+    const element = await meterWithFigures(44156, 170000)
+
+    expect(text(element)).toContain("€44,156")
+    expect(text(element)).toContain("of €170,000")
+    expect(text(element)).toContain("26%")
+    expect(text(element)).toContain("€125,844 short")
+    expect(bar(element).querySelector("div").getAttribute("style")).toBe("width: 26.0%")
+    expect(bar(element).getAttribute("aria-valuenow")).toBe("26")
+    expect(bar(element).getAttribute("aria-valuetext")).toBe("26%")
+    expect(bar(element).getAttribute("aria-label")).toBeTruthy()
+    expect(bar(element).getAttribute("role")).toBe("progressbar")
+    expect(bar(element).getAttribute("aria-valuemax")).toBe("100")
+  })
+
+  it("rounds the amounts to whole units", async () => {
+    const element = await meterWithFigures(46869.1, 170000)
+
+    expect(text(element)).toContain("€46,869")
+    expect(text(element)).not.toContain("46,869.1")
+  })
+
+  it("shows the campaign's own currency", async () => {
+    const element = await meterWithFigures(1000, 5000, "USD")
+    expect(text(element)).toContain("$1,000")
+  })
+
+  it("formats the amounts for the reader's language", async () => {
+    const previous = languageCode.get()
+    languageCode.set("de")
+    try {
+      const element = await meterWithFigures(44156, 170000)
+      expect(text(element)).toContain("170.000")
+    } finally {
+      languageCode.set(previous)
+    }
+  })
+
+  it("says nothing about a shortfall smaller than one unit", async () => {
+    const element = await meterWithFigures(169999.6, 170000)
+
+    expect(text(element)).not.toContain("short")
+    expect(bar(element)).not.toBeNull()
+  })
+
+  it("keeps the bar inside the goal but reports the real percentage", async () => {
+    const element = await meterWithFigures(180000, 170000)
+
+    expect(bar(element).querySelector("div").getAttribute("style")).toBe("width: 100.0%")
+    expect(bar(element).getAttribute("aria-valuenow")).toBe("100")
+    expect(bar(element).getAttribute("aria-valuetext")).toBe("106%")
+    expect(text(element)).not.toContain("short")
+  })
+
+  it("renders nothing at all without figures", async () => {
+    const element = document.createElement("donation-meter") as any
+    document.body.appendChild(element)
+    await element.updateComplete
+
+    expect(bar(element)).toBeNull()
+    expect(text(element)).toBe("")
+  })
+
+  it("renders nothing when a host sets figures the feed rules would refuse", async () => {
+    const element = await meterWithFigures(44156, 170000, "12$")
+
+    expect(bar(element)).toBeNull()
+    expect(text(element)).toBe("")
+  })
+
+  it("ignores a feed when a host set figures the rules refuse", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => feedWith({ raised: 44156, goal: 170000, currency: "EUR" }),
+    } as Response)
+
+    const element = document.createElement("donation-meter") as any
+    element.funding = { raised: 44156, goal: 170000, currency: "12$" }
+    element.setAttribute("url", FEED_URL)
+    document.body.appendChild(element)
+    await element.updateComplete
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    await element.updateComplete
+
+    expect(text(element)).toBe("")
+  })
+
+  it("reads the figures from the news feed", async () => {
+    const element = await meterFromFeed(feedWith({ raised: 44156, goal: 170000, currency: "EUR" }))
+
+    expect(global.fetch).toHaveBeenCalledWith(FEED_URL)
+    expect(text(element)).toContain("€44,156")
+  })
+
+  it("renders nothing when the feed carries an incomplete campaign", async () => {
+    const element = await meterFromFeed(feedWith({ raised: 44156, currency: "EUR" }))
+    expect(text(element)).toBe("")
+  })
+
+  it("renders nothing when the feed cannot be read", async () => {
+    // The body is a perfectly good feed: only the failed status may keep it off the page.
+    const element = await meterFromFeed(
+      feedWith({ raised: 44156, goal: 170000, currency: "EUR" }),
+      false
+    )
+    expect(text(element)).toBe("")
+  })
+
+  it("renders nothing when the feed is not the feed", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("not json")
+      },
+    } as unknown as Response)
+
+    const element = document.createElement("donation-meter") as any
+    element.setAttribute("url", FEED_URL)
+    document.body.appendChild(element)
+    await element.updateComplete
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    await element.updateComplete
+
+    expect(text(element)).toBe("")
+  })
+})

--- a/web-components/src/components/donation-meter/donation-meter.ts
+++ b/web-components/src/components/donation-meter/donation-meter.ts
@@ -1,0 +1,167 @@
+import { LitElement, html, css, nothing } from "lit"
+import { customElement, property } from "lit/decorators.js"
+import { localized, msg, str } from "@lit/localize"
+import { Task } from "@lit/task"
+import { languageCode } from "../../signals/app"
+import type { Funding, NewsData } from "../../types/news-feed"
+import { findFunding, parseFunding } from "../../utils/funding"
+
+/**
+ * `donation-meter` - how far a funding campaign has got, from the figures the
+ * news feed publishes. Point `url` at a feed the page is allowed to fetch.
+ *
+ * @customElement
+ * @lit-element
+ * @example
+ * <donation-meter
+ *   url="https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"
+ * ></donation-meter>
+ */
+@customElement("donation-meter")
+@localized()
+export class DonationMeter extends LitElement {
+  /**
+   * News feed to read the figures from. Omit it when the figures are set
+   * directly on the `funding` property.
+   */
+  @property({ attribute: "url" }) url?: string
+
+  @property({ type: Object }) funding?: Funding
+
+  static override styles = css`
+    :host {
+      display: block;
+      width: 100%;
+    }
+
+    .figures {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 0.5rem;
+      margin-bottom: 0.35rem;
+    }
+
+    .raised {
+      font-size: 1.125rem;
+      font-weight: 700;
+    }
+
+    .goal,
+    .shortfall {
+      font-size: 0.8125rem;
+      opacity: 0.85;
+    }
+
+    .shortfall {
+      display: block;
+      margin-top: 0.35rem;
+    }
+
+    .bar {
+      position: relative;
+      height: 0.5rem;
+      border-radius: 0.25rem;
+      overflow: hidden;
+    }
+
+    /* The track takes the text colour, so the meter reads on any banner. The
+       fill cannot inherit its opacity, hence the separate layer. */
+    .bar::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background-color: currentColor;
+      opacity: 0.2;
+    }
+
+    .bar > div {
+      position: relative;
+      height: 100%;
+      border-radius: 0.25rem;
+      background-color: #ff6e78;
+    }
+  `
+
+  private _fundingTask = new Task(this, {
+    args: () => [this.url] as const,
+    task: async ([url]) => {
+      if (!url) {
+        return null
+      }
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+      return findFunding((await response.json()) as NewsData)
+    },
+  })
+
+  private format(amount: number, currency: string) {
+    return new Intl.NumberFormat(this.locale, {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    }).format(amount)
+  }
+
+  private get locale() {
+    return languageCode.get() || undefined
+  }
+
+  private renderMeter(funding: Funding | null) {
+    if (!funding) {
+      return nothing
+    }
+
+    const ratio = funding.raised / funding.goal
+    const progress = Math.min(Math.max(ratio, 0), 1)
+    const percent = new Intl.NumberFormat(this.locale, { style: "percent" }).format(ratio)
+    const raised = this.format(funding.raised, funding.currency)
+    const goal = this.format(funding.goal, funding.currency)
+    const missing = funding.goal - funding.raised
+
+    return html`
+      <div class="figures">
+        <span class="raised">${raised}</span>
+        <span class="goal">${msg(str`of ${goal}`)} · ${percent}</span>
+      </div>
+      <div
+        class="bar"
+        role="progressbar"
+        aria-label=${msg("Fundraiser progress")}
+        aria-valuemin="0"
+        aria-valuemax="100"
+        aria-valuenow=${Math.round(progress * 100)}
+        aria-valuetext=${percent}
+      >
+        <div style="width: ${(progress * 100).toFixed(1)}%"></div>
+      </div>
+      ${missing >= 1 ? this.renderShortfall(this.format(missing, funding.currency)) : nothing}
+    `
+  }
+
+  private renderShortfall(missing: string) {
+    return html`<span class="shortfall">${msg(str`${missing} short`)}</span>`
+  }
+
+  override render() {
+    if (this.funding) {
+      const { raised, goal, currency } = this.funding
+      return this.renderMeter(parseFunding(raised, goal, currency))
+    }
+
+    return this._fundingTask.render({
+      // No figures beats wrong figures: the host keeps its static donation ask.
+      pending: () => nothing,
+      error: () => nothing,
+      complete: (funding) => this.renderMeter(funding),
+    })
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "donation-meter": DonationMeter
+  }
+}

--- a/web-components/src/components/donation-meter/donation-meter.ts
+++ b/web-components/src/components/donation-meter/donation-meter.ts
@@ -1,8 +1,10 @@
-import { LitElement, html, css, nothing } from "lit"
+import { LitElement, html, css, nothing, type PropertyValues } from "lit"
 import { customElement, property } from "lit/decorators.js"
 import { localized, msg, str } from "@lit/localize"
-import { Task } from "@lit/task"
+import { Task, TaskStatus } from "@lit/task"
 import { languageCode } from "../../signals/app"
+import { EventState, EventType } from "../../constants"
+import type { BasicStateEventDetail } from "../../types"
 import type { Funding, NewsData } from "../../types/news-feed"
 import { findFunding, parseFunding } from "../../utils/funding"
 
@@ -16,6 +18,8 @@ import { findFunding, parseFunding } from "../../utils/funding"
  * <donation-meter
  *   url="https://raw.githubusercontent.com/openfoodfacts/smooth-app_assets/refs/heads/main/prod/tagline/web/main.json"
  * ></donation-meter>
+ *
+ * @fires {EventType.DONATION_METER_STATE} - When the element starts or stops showing figures.
  */
 @customElement("donation-meter")
 @localized()
@@ -27,6 +31,8 @@ export class DonationMeter extends LitElement {
   @property({ attribute: "url" }) url?: string
 
   @property({ type: Object }) funding?: Funding
+
+  private lastState?: EventState
 
   static override styles = css`
     :host {
@@ -97,6 +103,45 @@ export class DonationMeter extends LitElement {
     },
   })
 
+  override connectedCallback() {
+    super.connectedCallback()
+    // An announcement made while the host was detached never reached it, so the
+    // element has to say where it stands again rather than dedupe against it.
+    this.lastState = undefined
+    this.requestUpdate()
+  }
+
+  private get visibleFunding(): Funding | null {
+    if (this.funding) {
+      const { raised, goal, currency } = this.funding
+      return parseFunding(raised, goal, currency)
+    }
+    if (this._fundingTask.status !== TaskStatus.COMPLETE) {
+      return null
+    }
+    return this._fundingTask.value ?? null
+  }
+
+  private get state(): EventState {
+    if (!this.funding && this._fundingTask.status === TaskStatus.PENDING) {
+      return EventState.LOADING
+    }
+    return this.visibleFunding ? EventState.HAS_DATA : EventState.NO_DATA
+  }
+
+  override updated(changedProperties: PropertyValues) {
+    super.updated(changedProperties)
+    const state = this.state
+    if (state === this.lastState) {
+      return
+    }
+    this.lastState = state
+    const detail: BasicStateEventDetail = { state }
+    this.dispatchEvent(
+      new CustomEvent(EventType.DONATION_METER_STATE, { detail, bubbles: true, composed: true })
+    )
+  }
+
   private format(amount: number, currency: string) {
     return new Intl.NumberFormat(this.locale, {
       style: "currency",
@@ -145,18 +190,9 @@ export class DonationMeter extends LitElement {
     return html`<span class="shortfall">${msg(str`${missing} short`)}</span>`
   }
 
+  // No figures beats wrong figures: the host keeps its static donation ask.
   override render() {
-    if (this.funding) {
-      const { raised, goal, currency } = this.funding
-      return this.renderMeter(parseFunding(raised, goal, currency))
-    }
-
-    return this._fundingTask.render({
-      // No figures beats wrong figures: the host keeps its static donation ask.
-      pending: () => nothing,
-      error: () => nothing,
-      complete: (funding) => this.renderMeter(funding),
-    })
+    return this.renderMeter(this.visibleFunding)
   }
 }
 

--- a/web-components/src/components/news-feed/news-feed.test.ts
+++ b/web-components/src/components/news-feed/news-feed.test.ts
@@ -1,0 +1,79 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import dayjs from "dayjs/esm"
+
+beforeAll(async () => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  })
+
+  await import("./news-feed")
+})
+
+const inDays = (days: number) => dayjs().add(days, "day").format("YYYY-MM-DD HH:mm:ss")
+
+const feedWith = (campaign: Record<string, unknown>) => ({
+  news: {
+    donation_campaign: {
+      translations: { default: { title: "Campaign", message: "Give" } },
+      start_date: inDays(-30),
+      end_date: inDays(150),
+      ...campaign,
+    },
+  },
+  tagline_feed: { default: { news: [{ id: "donation_campaign" }] } },
+})
+
+const renderFeed = async (body: unknown) => {
+  vi.mocked(global.fetch).mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response)
+
+  const element = document.createElement("news-feed") as any
+  element.setAttribute("url", "https://example.org/main.json")
+  element.setAttribute("lang", "en")
+  document.body.appendChild(element)
+
+  for (let attempt = 0; attempt < 20; attempt++) {
+    await element.updateComplete
+    if (element.shadowRoot.querySelector(".news-item")) {
+      break
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  return element
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+})
+
+describe("news-feed", () => {
+  it("shows a meter on a campaign that publishes figures", async () => {
+    const element = await renderFeed(feedWith({ raised: 44156, goal: 170000, currency: "EUR" }))
+
+    const meter = element.shadowRoot.querySelector("donation-meter")
+    expect(meter).not.toBeNull()
+    expect(meter.funding).toEqual({ raised: 44156, goal: 170000, currency: "EUR" })
+  })
+
+  it("shows the news item without a meter when there are no figures", async () => {
+    const element = await renderFeed(feedWith({}))
+
+    expect(element.shadowRoot.querySelector(".news-item")).not.toBeNull()
+    expect(element.shadowRoot.querySelector("donation-meter")).toBeNull()
+  })
+
+  it("shows no meter when the campaign publishes only part of the figures", async () => {
+    const element = await renderFeed(feedWith({ raised: 44156, currency: "EUR" }))
+
+    expect(element.shadowRoot.querySelector(".news-item")).not.toBeNull()
+    expect(element.shadowRoot.querySelector("donation-meter")).toBeNull()
+  })
+})

--- a/web-components/src/components/news-feed/news-feed.ts
+++ b/web-components/src/components/news-feed/news-feed.ts
@@ -5,6 +5,8 @@ import type { NewsData, ProcessedNewsItem } from "../../types/news-feed"
 import { Task } from "@lit/task"
 import { sanitizeHtml } from "../../utils/html"
 import dayjs from "dayjs/esm"
+import { parseFunding } from "../../utils/funding"
+import "../donation-meter/donation-meter"
 
 /**
  * `news-feed` - A web component that displays news items from a JSON feed.
@@ -130,6 +132,12 @@ export class NewsFeed extends LitElement {
       color: #1f2937;
     }
 
+    .funding {
+      display: block;
+      margin-top: 0.75rem;
+      color: #1f2937;
+    }
+
     /* Message Type Styles */
     .info {
       border-left: 4px solid #3b82f6; /* Blue */
@@ -193,6 +201,9 @@ export class NewsFeed extends LitElement {
       }
       .message strong,
       .message b {
+        color: #fafafa;
+      }
+      .funding {
         color: #fafafa;
       }
       .info {
@@ -280,6 +291,7 @@ export class NewsFeed extends LitElement {
         min_app_version: details.min_app_version,
         max_app_version: details.max_app_version,
         enabled: details.enabled !== false, // Default to true if not explicitly false
+        funding: parseFunding(details.raised, details.goal, details.currency) ?? undefined,
         message_type: (details.message_type || "info").toLowerCase(), // Default to 'info'
         // Add other fields from 'details' if needed for filtering later
       })
@@ -450,6 +462,9 @@ export class NewsFeed extends LitElement {
         <p class="message">
           ${sanitizeHtml(item.parsedMessage) || item.message || "No message content."}
         </p>
+        ${item.funding
+          ? html`<donation-meter class="funding" .funding=${item.funding}></donation-meter>`
+          : ""}
       </div>
     `
 

--- a/web-components/src/constants.ts
+++ b/web-components/src/constants.ts
@@ -22,6 +22,7 @@ export enum EventType {
   BARCODE_SCANNER_STATE = "barcode-scanner-state",
   INGREDIENT_SPELLCHECK_STATE = "ingredient-spellcheck-state",
   INGREDIENT_DETECTION_STATE = "ingredient-detection-state",
+  DONATION_METER_STATE = "donation-meter-state",
   INPUT = "INPUT",
 }
 

--- a/web-components/src/off-webcomponents.ts
+++ b/web-components/src/off-webcomponents.ts
@@ -6,6 +6,7 @@ export { RobotoffIngredientSpellcheck } from "./components/robotoff-ingredient-s
 export { RobotoffContributionMessage } from "./components/robotoff-contribution-message/robotoff-contribution-message"
 export { KnowledgePanelsComponent } from "./components/knowledge-panels/knowledge-panels"
 export { DonationBanner } from "./components/donation-banner/donation-banner"
+export { DonationMeter } from "./components/donation-meter/donation-meter"
 export { MobileBadges } from "./components/mobile-badges/mobile-badges"
 export { DownloadAppQrCode } from "./components/download-app-qr-code/download-app-qr-code"
 export { BarcodeScanner } from "./components/barcode-scanner/barcode-scanner"

--- a/web-components/src/types/news-feed.ts
+++ b/web-components/src/types/news-feed.ts
@@ -1,4 +1,13 @@
 /**
+ * Figures a funding campaign publishes in the feed.
+ */
+export interface Funding {
+  raised: number
+  goal: number
+  currency: string
+}
+
+/**
  * This is the format of the JSON file where data is stored
  */
 export interface NewsData {
@@ -23,6 +32,9 @@ export interface NewsData {
       max_app_version?: string
       enabled?: boolean
       message_type?: string
+      raised?: number
+      goal?: number
+      currency?: string
     }
   }
   tagline_feed: {
@@ -52,4 +64,5 @@ export interface ProcessedNewsItem {
   max_app_version?: string
   enabled: boolean
   message_type: string
+  funding?: Funding
 }

--- a/web-components/src/utils/funding.test.ts
+++ b/web-components/src/utils/funding.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest"
+import dayjs from "dayjs/esm"
+import { findFunding, parseFunding } from "./funding"
+import type { NewsData } from "../types/news-feed"
+
+const inDays = (days: number) => dayjs().add(days, "day").format("YYYY-MM-DD HH:mm:ss")
+
+const feed = (campaign: Record<string, unknown>, ids: string[] = ["donation_campaign"]): NewsData =>
+  ({
+    news: {
+      donation_campaign: {
+        translations: { default: { title: "Campaign", message: "Give" } },
+        start_date: inDays(-30),
+        end_date: inDays(150),
+        ...campaign,
+      },
+      plain_news: {
+        translations: { default: { title: "News", message: "Read" } },
+      },
+    },
+    tagline_feed: { default: { news: ids.map((id) => ({ id })) } },
+  }) as unknown as NewsData
+
+describe("parseFunding", () => {
+  it("accepts a complete set of figures", () => {
+    expect(parseFunding(44156, 170000, "EUR")).toEqual({
+      raised: 44156,
+      goal: 170000,
+      currency: "EUR",
+    })
+  })
+
+  it("refuses a campaign that publishes only some of them", () => {
+    expect(parseFunding(44156, 170000, undefined)).toBeNull()
+    expect(parseFunding(44156, undefined, "EUR")).toBeNull()
+    expect(parseFunding(undefined, 170000, "EUR")).toBeNull()
+  })
+
+  it("refuses figures that cannot produce a ratio", () => {
+    expect(parseFunding(44156, 0, "EUR")).toBeNull()
+    expect(parseFunding(-1, 170000, "EUR")).toBeNull()
+    expect(parseFunding(Infinity, 170000, "EUR")).toBeNull()
+  })
+
+  it("refuses a goal below one unit, which is a misplaced decimal point", () => {
+    expect(parseFunding(0, 0.17, "EUR")).toBeNull()
+    expect(parseFunding(1e300, 1e-300, "EUR")).toBeNull()
+  })
+
+  it("refuses anything Intl would reject as a currency", () => {
+    expect(parseFunding(44156, 170000, "€")).toBeNull()
+    expect(parseFunding(44156, 170000, "EUROS")).toBeNull()
+    expect(parseFunding(44156, 170000, "12$")).toBeNull()
+    expect(parseFunding(44156, 170000, "E U")).toBeNull()
+  })
+
+  it("accepts a three letter code Intl can format", () => {
+    for (const currency of ["EUR", "usd", "XOF"]) {
+      const funding = parseFunding(1, 2, currency)!
+      expect(funding).not.toBeNull()
+      expect(() =>
+        new Intl.NumberFormat("en", { style: "currency", currency: funding.currency }).format(1)
+      ).not.toThrow()
+    }
+  })
+
+  it("refuses figures published as text", () => {
+    expect(parseFunding("44156", "170000", "EUR")).toBeNull()
+    expect(parseFunding("44156", 170000, "EUR")).toBeNull()
+    expect(parseFunding(44156, "170000", "EUR")).toBeNull()
+  })
+
+  it("accepts zero raised, which is a campaign that just opened", () => {
+    expect(parseFunding(0, 170000, "EUR")).not.toBeNull()
+  })
+})
+
+describe("findFunding", () => {
+  it("finds the running campaign that publishes figures", () => {
+    expect(findFunding(feed({ raised: 44156, goal: 170000, currency: "EUR" }))).toEqual({
+      raised: 44156,
+      goal: 170000,
+      currency: "EUR",
+    })
+  })
+
+  it("skips an item that carries no figures", () => {
+    expect(findFunding(feed({}))).toBeNull()
+  })
+
+  it("skips a campaign that has ended", () => {
+    const ended = feed({
+      raised: 44156,
+      goal: 170000,
+      currency: "EUR",
+      start_date: inDays(-90),
+      end_date: inDays(-1),
+    })
+    expect(findFunding(ended)).toBeNull()
+  })
+
+  it("skips a campaign that has not started", () => {
+    const future = feed({
+      raised: 0,
+      goal: 170000,
+      currency: "EUR",
+      start_date: inDays(10),
+      end_date: inDays(200),
+    })
+    expect(findFunding(future)).toBeNull()
+  })
+
+  it("skips a campaign the feed disabled", () => {
+    expect(findFunding(feed({ raised: 1, goal: 2, currency: "EUR", enabled: false }))).toBeNull()
+  })
+
+  it("keeps looking past the items that carry no figures", () => {
+    const data = feed({ raised: 44156, goal: 170000, currency: "EUR" }, [
+      "plain_news",
+      "donation_campaign",
+    ])
+    expect(findFunding(data)?.raised).toBe(44156)
+  })
+
+  it("ignores an item the tagline feed does not list", () => {
+    const data = feed({ raised: 44156, goal: 170000, currency: "EUR" }, ["plain_news"])
+    expect(findFunding(data)).toBeNull()
+  })
+
+  it("skips an ended campaign and takes the running one behind it", () => {
+    const data = feed({ raised: 44156, goal: 170000, currency: "EUR" }, [
+      "old_campaign",
+      "donation_campaign",
+    ])
+    ;(data.news as any).old_campaign = {
+      translations: { default: { title: "Old", message: "Gave" } },
+      raised: 1,
+      goal: 2,
+      currency: "EUR",
+      start_date: inDays(-200),
+      end_date: inDays(-100),
+    }
+    expect(findFunding(data)?.raised).toBe(44156)
+  })
+
+  it("survives a feed that is not the feed", () => {
+    expect(findFunding({} as NewsData)).toBeNull()
+    expect(findFunding({ news: {}, tagline_feed: { default: { news: [null] } } } as any)).toBeNull()
+    expect(findFunding({ tagline_feed: { default: { news: {} } } } as any)).toBeNull()
+    expect(findFunding({ tagline_feed: { default: { news: [{ id: "gone" }] } } } as any)).toBeNull()
+  })
+})

--- a/web-components/src/utils/funding.ts
+++ b/web-components/src/utils/funding.ts
@@ -1,0 +1,47 @@
+import dayjs from "dayjs/esm"
+import type { Funding, NewsData } from "../types/news-feed"
+
+/**
+ * A campaign that publishes only some of the three fields renders no meter at
+ * all, so a half-written feed never becomes a wrong number on the page.
+ */
+export const parseFunding = (raised: unknown, goal: unknown, currency: unknown): Funding | null => {
+  if (typeof raised !== "number" || typeof goal !== "number" || typeof currency !== "string") {
+    return null
+  }
+  if (!isFinite(raised) || !isFinite(goal) || raised < 0 || goal < 1) {
+    return null
+  }
+  // Intl throws unless the code is three ASCII letters.
+  if (!/^[A-Za-z]{3}$/.test(currency)) {
+    return null
+  }
+  return { raised, goal, currency }
+}
+
+const isLive = (start?: string, end?: string) => {
+  const now = dayjs()
+  const startDate = start && dayjs(start).isValid() ? dayjs(start) : null
+  const endDate = end && dayjs(end).isValid() ? dayjs(end) : null
+  return !((startDate && now.isBefore(startDate)) || (endDate && now.isAfter(endDate)))
+}
+
+/** The first campaign the tagline feed lists that is running and publishes figures. */
+export const findFunding = (data: NewsData): Funding | null => {
+  const items = data?.tagline_feed?.default?.news
+  if (!Array.isArray(items)) {
+    return null
+  }
+
+  for (const item of items) {
+    const details = item?.id ? data.news?.[item.id] : undefined
+    if (!details || details.enabled === false || !isLive(details.start_date, details.end_date)) {
+      continue
+    }
+    const funding = parseFunding(details.raised, details.goal, details.currency)
+    if (funding) {
+      return funding
+    }
+  }
+  return null
+}

--- a/web-components/xliff/af.xlf
+++ b/web-components/xliff/af.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/af.xlf
+++ b/web-components/xliff/af.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/am.xlf
+++ b/web-components/xliff/am.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/am.xlf
+++ b/web-components/xliff/am.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ar.xlf
+++ b/web-components/xliff/ar.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ar.xlf
+++ b/web-components/xliff/ar.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">تدوير الصورة إلى اليمين</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">ساعدنا في إعلام ملايين المستهلكين حول العالم بما يأكلون</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">تساهم تبرعاتكم في تمويل العمليات اليومية لجمعيتنا غير الربحية:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">دعم تقدم أبحاث الصحة العامة.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">كل تبرع يُحسب! نقدّر دعمكم لتعزيز الشفافية الغذائية في العالم.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">انا ادعم</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">تبرع صورة المجموعة <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">يرجى التبرع لحملة جمع التبرعات الخاصة بنا <x id="0" equiv-text="${this.currentYear}"/></target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ay.xlf
+++ b/web-components/xliff/ay.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/ay.xlf
+++ b/web-components/xliff/ay.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/az.xlf
+++ b/web-components/xliff/az.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Dünyadakı milyonlarla istehlakçını nə yedikləri barədə məlumatlandırmağımıza kömək edin</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">İanələriniz qeyri-kommersiya birliyimizin gündəlik fəaliyyətini maliyyələşdirir:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">ictimai səhiyyə tədqiqatlarının inkişafını dəstəkləmək.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Hər bir ianə vacibdir! Dünyada qida şəffaflığının daha da artırılmasında göstərdiyiniz dəstəyə görə minnətdarıq.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">DƏSTƏKLƏYİRƏM</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/az.xlf
+++ b/web-components/xliff/az.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/be.xlf
+++ b/web-components/xliff/be.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-review-translation" state-qualifier="leveraged-mt">ахвяраванне групавога фота <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-review-translation" state-qualifier="leveraged-mt">Калі ласка, ахвяруйце на наш збор сродкаў <x id="0" equiv-text="${this.currentYear}"/></target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/be.xlf
+++ b/web-components/xliff/be.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/bg.xlf
+++ b/web-components/xliff/bg.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/bg.xlf
+++ b/web-components/xliff/bg.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Помогнете ни да информираме милиони потребители по света за това какво ядат</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Вашите дарения финансират ежедневните операции на нашата асоциация с нестопанска цел:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">да подпомагаме напредъка в научните изследвания в областта на общественото здраве.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Всяко дарение има значение! Оценяваме вашата подкрепа за осигуряване на допълнителна прозрачност на храните в света.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">ПОДКРЕПЯМ</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/bi.xlf
+++ b/web-components/xliff/bi.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/bi.xlf
+++ b/web-components/xliff/bi.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/bn.xlf
+++ b/web-components/xliff/bn.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/bn.xlf
+++ b/web-components/xliff/bn.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/bs.xlf
+++ b/web-components/xliff/bs.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/bs.xlf
+++ b/web-components/xliff/bs.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ca.xlf
+++ b/web-components/xliff/ca.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ca.xlf
+++ b/web-components/xliff/ca.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-review-translation" state-qualifier="leveraged-mt">donació de fotos de grup <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-review-translation" state-qualifier="leveraged-mt">Si us plau, doneu-ho a la nostra recaptació de fons <x id="0" equiv-text="${this.currentYear}"/></target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ch.xlf
+++ b/web-components/xliff/ch.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/ch.xlf
+++ b/web-components/xliff/ch.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/cs.xlf
+++ b/web-components/xliff/cs.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Otočit obrázek vpravo</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Pomozte nám informovat miliony spotřebitelů po celém světě o tom, co jedí</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Vaše dary financují každodenní provoz našeho neziskového sdružení:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">podporovat pokrok ve výzkumu veřejného zdraví.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Každý dar se počítá! Vážíme si vaší podpory při zavádění další transparentnosti potravin ve světě.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">PODPORUJI</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">dar skupinové fotografie <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Prosím, přispějte na naši sbírku <x id="0" equiv-text="${this.currentYear}"/></target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/cs.xlf
+++ b/web-components/xliff/cs.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/cy.xlf
+++ b/web-components/xliff/cy.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/cy.xlf
+++ b/web-components/xliff/cy.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/da.xlf
+++ b/web-components/xliff/da.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/da.xlf
+++ b/web-components/xliff/da.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Roter billedet til højre</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Hjælp os med at informere millioner af forbrugere rundt om i verden om, hvad de spiser</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Dine donationer finansierer den daglige drift af vores non-profit forening:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">støtte forskning inden for folkesundhed.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Hver donation tæller! Vi sætter pris på din støtte til at bringe yderligere fødevaregennemsigtighed i verden.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">JEG STØTTER</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">gruppefotodonation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Giv venligst til vores <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/de.xlf
+++ b/web-components/xliff/de.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Bild nach rechts drehen</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Helfen Sie uns, Millionen von Verbrauchern auf der ganzen Welt darüber zu informieren, was sie essen</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Ihre Spenden finanzieren den laufenden Betrieb unserer gemeinnützigen Vereinigung:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">die Förderung der Forschung im Bereich der öffentlichen Gesundheit zu unterstützen.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Jede Spende zählt! Wir freuen uns über Ihre Unterstützung bei der Schaffung von mehr Lebensmitteltransparenz in der Welt.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">ICH UNTERSTÜTZE</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">Gruppenfoto spende <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Bitte unterstützen Sie unsere Spendenaktion <x id="0" equiv-text="${this.currentYear}"/></target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1009,6 +997,15 @@ sich zu beteiligen oder Feedback zu geben</target>
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/de.xlf
+++ b/web-components/xliff/de.xlf
@@ -1001,6 +1001,15 @@ sich zu beteiligen oder Feedback zu geben</target>
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/dv.xlf
+++ b/web-components/xliff/dv.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/dv.xlf
+++ b/web-components/xliff/dv.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/dz.xlf
+++ b/web-components/xliff/dz.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/dz.xlf
+++ b/web-components/xliff/dz.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/el.xlf
+++ b/web-components/xliff/el.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/el.xlf
+++ b/web-components/xliff/el.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Περιστροφή εικόνας δεξιά</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Βοηθήστε μας να ενημερώσουμε εκατομμύρια καταναλωτές σε όλο τον κόσμο για το τι τρώνε</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Οι δωρεές σας χρηματοδοτούν τις καθημερινές λειτουργίες του μη κερδοσκοπικού σωματείου μας:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">για την υποστήριξη της προόδου της έρευνας για τη δημόσια υγεία.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Κάθε δωρεά μετράει! Εκτιμούμε την υποστήριξή σας για την περαιτέρω διαφάνεια των τροφίμων στον κόσμο.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">ΣΤΗΡΙΖΩ</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">δωρεά ομαδικής φωτογραφίας <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Παρακαλούμε δωρίστε στον Έρανό μας για το <x id="0" equiv-text="${this.currentYear}"/></target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/en.xlf
+++ b/web-components/xliff/en.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/en.xlf
+++ b/web-components/xliff/en.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="translated">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="translated">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="translated">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="translated">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="translated">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/es.xlf
+++ b/web-components/xliff/es.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Girar imagen a la derecha</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Ayúdanos a informar a millones de consumidores de todo el mundo sobre lo que comen.</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Sus donaciones financian las operaciones diarias de nuestra asociación sin fines de lucro:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">Apoyar el avance de la investigación en salud pública.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">¡Cada donación cuenta! Agradecemos su apoyo para lograr una mayor transparencia alimentaria en el mundo.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">YO APOYO</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-review-translation" state-qualifier="leveraged-mt">donación de fotos grupales <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-review-translation" state-qualifier="leveraged-mt">Por favor, dona a nuestra recaudación de fondos <x id="0" equiv-text="${this.currentYear}"/></target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/es.xlf
+++ b/web-components/xliff/es.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/et.xlf
+++ b/web-components/xliff/et.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/et.xlf
+++ b/web-components/xliff/et.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/eu.xlf
+++ b/web-components/xliff/eu.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/eu.xlf
+++ b/web-components/xliff/eu.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/fa.xlf
+++ b/web-components/xliff/fa.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">به ما کمک کنید تا میلیون‌ها مصرف‌کننده در سراسر جهان را در مورد آنچه می‌خورند آگاه کنیم</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">کمک‌های مالی شما، هزینه‌های روزمره‌ی انجمن غیرانتفاعی ما را تأمین می‌کند:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">حمایت از پیشرفت تحقیقات در حوزه سلامت عمومی</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">هر کمک مالی ارزشمند است! ما از حمایت شما در ایجاد شفافیت بیشتر در زمینه مواد غذایی در جهان قدردانی می‌کنیم.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">من حمایت می‌کنم</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/fa.xlf
+++ b/web-components/xliff/fa.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/fi.xlf
+++ b/web-components/xliff/fi.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/fi.xlf
+++ b/web-components/xliff/fi.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Kierrä kuvaa oikealle</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Auta meitä kertomaan miljoonille kuluttajille eri puolilla maailmaa siitä, mitä he syövät</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Lahjoitustesi avulla voittoa tavoittelematon järjestömme</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">tukemaan kansanterveystutkimuksen edistämistä.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Jokainen lahjoitus on tärkeä! Arvostamme sitä, että tuet meitä maailman elintarviketeollisuuden läpinäkyvyyden lisäämisessä.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">LAHJOITA</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/fj.xlf
+++ b/web-components/xliff/fj.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/fj.xlf
+++ b/web-components/xliff/fj.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/fr.xlf
+++ b/web-components/xliff/fr.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Faire pivoter l'image vers la droite</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Aidez-nous à informer des millions de consommateurs à travers le monde sur ce qu'ils mangent</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Vos dons financent le fonctionnement quotidien de notre association à but non lucratif :</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">soutenir l’avancement de la recherche en santé publique.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Chaque don compte ! Nous apprécions votre soutien pour une plus grande transparence alimentaire dans le monde.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">JE SOUTIENS</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">photo de groupe pour les dons <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Veuillez faire un don à notre collecte de fonds <x id="0" equiv-text="${this.currentYear}"/></target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1008,6 +996,18 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+  <target state="translated">Il nous manque encore 120 000 € pour terminer 2026 !</target>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+  <target state="translated">Devenez mécène d'Open Food Facts</target>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
+  <target state="translated">Si chaque visiteur ce mois-ci cliquait sur Faire un don et donnait seulement 1 €, nous aurions plus de 8 fois notre budget annuel !</target>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/fr.xlf
+++ b/web-components/xliff/fr.xlf
@@ -1000,6 +1000,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ga.xlf
+++ b/web-components/xliff/ga.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ga.xlf
+++ b/web-components/xliff/ga.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/gd.xlf
+++ b/web-components/xliff/gd.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/gd.xlf
+++ b/web-components/xliff/gd.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/gl.xlf
+++ b/web-components/xliff/gl.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/gl.xlf
+++ b/web-components/xliff/gl.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/gn.xlf
+++ b/web-components/xliff/gn.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/gn.xlf
+++ b/web-components/xliff/gn.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/gv.xlf
+++ b/web-components/xliff/gv.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/gv.xlf
+++ b/web-components/xliff/gv.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/he.xlf
+++ b/web-components/xliff/he.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/he.xlf
+++ b/web-components/xliff/he.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">היפוך התמונה לימין</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">נשמח לסיוע בהפצת ידע למיליוני צרכנים ברחבי העולם לגבי מה הם מכניסים לפה</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">התרומות שלך מממנות את הפעילויות היומיומיות של העמותה שלנו שאינה למטרות רווח:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">לתמוך בהתפתחות של מחקרי בריאות הציבור.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">כל תרומה נחשבת! אנו מעכירים את התמיכה שלך בהפצת שקיפות מזון בעולם.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">ארצה לתמוך</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">תמונה קבוצתית שנתרמה <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">נא לתרום לגיוס התרומות לשנת <x id="0" equiv-text="${this.currentYear}"/></target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/hi.xlf
+++ b/web-components/xliff/hi.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/hi.xlf
+++ b/web-components/xliff/hi.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ho.xlf
+++ b/web-components/xliff/ho.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/ho.xlf
+++ b/web-components/xliff/ho.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/hr.xlf
+++ b/web-components/xliff/hr.xlf
@@ -1001,6 +1001,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/hr.xlf
+++ b/web-components/xliff/hr.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Pomozite nam informirati milijune potrošača diljem svijeta o tome što jedu</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Vaše donacije financiraju svakodnevno poslovanje naše neprofitne udruge:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">podržati napredak istraživanja javnog zdravstva.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Svaka donacija je važna! Cijenimo vašu podršku u ostvarivanju veće transparentnosti hrane u svijetu.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">PODRŽAVAM</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1009,6 +997,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ht.xlf
+++ b/web-components/xliff/ht.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ht.xlf
+++ b/web-components/xliff/ht.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/hu.xlf
+++ b/web-components/xliff/hu.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/hu.xlf
+++ b/web-components/xliff/hu.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Segítsen nekünk tájékoztatni a fogyasztók millióit világszerte arról, hogy mit esznek</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Adományaival nonprofit egyesületünk mindennapi működését finanszírozza:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">a közegészségügyi kutatás előmozdításának támogatása.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Minden adomány számít! Nagyra értékeljük az élelmiszerek globális átláthatóságának javításáért nyújtott támogatását.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">TÁMOGATOM</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">csoportkép adományozás <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Kérjük adományozzon <x id="0" equiv-text="${this.currentYear}"/> évi adománygyűjtésünkön</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/hy.xlf
+++ b/web-components/xliff/hy.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/hy.xlf
+++ b/web-components/xliff/hy.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/id.xlf
+++ b/web-components/xliff/id.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/id.xlf
+++ b/web-components/xliff/id.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Putar gambar ke kanan</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Bantu kami menginformasikan kepada jutaan konsumen di seluruh dunia tentang apa yang mereka makan</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Donasi Anda mendanai operasional sehari-hari asosiasi nirlaba kami:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">mendukung kemajuan penelitian kesehatan masyarakat.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Setiap donasi sangat berarti! Kami menghargai dukungan Anda dalam mewujudkan transparansi pangan di dunia.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">SAYA MENDUKUNG</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">foto grup donasi <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Silakan berdonasi ke <x id="0" equiv-text="${this.currentYear}"/> acara penggalangan dana kami</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/is.xlf
+++ b/web-components/xliff/is.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/is.xlf
+++ b/web-components/xliff/is.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/it.xlf
+++ b/web-components/xliff/it.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Aiutaci a informare milioni di consumatori in tutto il mondo su ciò che mangiano</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Le tue donazioni finanziano le attività quotidiane della nostra associazione senza scopo di lucro:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">sostenere il progresso della ricerca sulla salute pubblica.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Ogni donazione conta! Apprezziamo il tuo supporto nel portare maggiore trasparenza alimentare nel mondo.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">SOSTENGO</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/it.xlf
+++ b/web-components/xliff/it.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ja.xlf
+++ b/web-components/xliff/ja.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ja.xlf
+++ b/web-components/xliff/ja.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">画像を右に回転</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">世界中の何百万人もの消費者に、彼らが何を食べているかを伝えるお手伝いをしてください</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">皆様のご寄付は、当非営利団体の日常的な運営資金となります。</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">公衆衛生研究の進歩を支援する。</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">一つ一つの寄付が大切です！世界の食品の透明性向上に貢献できるよう、皆様のご支援をお願いいたします。</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">私は支持する</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-review-translation" state-qualifier="leveraged-mt">集合写真の寄付 <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-review-translation" state-qualifier="leveraged-mt"><x id="0" equiv-text="${this.currentYear}"/> 募金活動にご協力ください</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,19 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+  <target state="translated">募金の進捗状況</target>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+  <target state="translated">2026年を終えるには、まだ120,000ユーロ必要です！</target>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+  <target state="translated">Open Food Facts の支援者になってください</target>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
+  <target state="translated">今月、すべての訪問者が「寄付する」をクリックして1ユーロずつ寄付してくれたら、年間予算の8倍以上になります！</target>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ka.xlf
+++ b/web-components/xliff/ka.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ka.xlf
+++ b/web-components/xliff/ka.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">დაგვეხმარეთ, მთელ მსოფლიოში მილიონობით მომხმარებელს ვაცნობოთ, თუ რას მიირთმევენ</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">თქვენი შემოწირულობები აფინანსებს ჩვენი არაკომერციული ასოციაციის ყოველდღიურ საქმიანობას:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">საზოგადოებრივი ჯანდაცვის კვლევის წინსვლის მხარდაჭერა.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">თითოეული შემოწირულობა მნიშვნელოვანია! ჩვენ ვაფასებთ თქვენს მხარდაჭერას მსოფლიოში საკვების გამჭვირვალობის გაზრდის საქმეში.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">მე მხარს ვუჭერ</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/kk.xlf
+++ b/web-components/xliff/kk.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/kk.xlf
+++ b/web-components/xliff/kk.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/kl.xlf
+++ b/web-components/xliff/kl.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/kl.xlf
+++ b/web-components/xliff/kl.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/km.xlf
+++ b/web-components/xliff/km.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/km.xlf
+++ b/web-components/xliff/km.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ko.xlf
+++ b/web-components/xliff/ko.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ko.xlf
+++ b/web-components/xliff/ko.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">전 세계 수백만 명의 소비자들이 무엇을 먹는지에 대한 정보를 얻을 수 있도록 도와주세요.</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">여러분의 기부금은 저희 비영리 단체의 일상적인 운영에 사용됩니다.</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">공중보건 연구의 발전을 지원합니다.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">모든 기부가 소중합니다! 세계 식품 투명성 제고를 위한 여러분의 지원에 감사드립니다.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">저는 지지합니다</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-review-translation" state-qualifier="leveraged-mt">단체 사진 기부 <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-review-translation" state-qualifier="leveraged-mt">저희 <x id="0" equiv-text="${this.currentYear}"/> 모금 행사에 기부해 주세요.</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ku.xlf
+++ b/web-components/xliff/ku.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ku.xlf
+++ b/web-components/xliff/ku.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ky.xlf
+++ b/web-components/xliff/ky.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ky.xlf
+++ b/web-components/xliff/ky.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/la.xlf
+++ b/web-components/xliff/la.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/la.xlf
+++ b/web-components/xliff/la.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/lb.xlf
+++ b/web-components/xliff/lb.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/lb.xlf
+++ b/web-components/xliff/lb.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/lo.xlf
+++ b/web-components/xliff/lo.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/lo.xlf
+++ b/web-components/xliff/lo.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/lt.xlf
+++ b/web-components/xliff/lt.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/lt.xlf
+++ b/web-components/xliff/lt.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Padėkite mums informuoti milijonus vartotojų visame pasaulyje apie tai, ką jie valgo</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Jūsų aukos finansuoja kasdienę mūsų ne pelno asociacijos veiklą:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">paremti visuomenės sveikatos tyrimų pažangą.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Kiekviena auka svarbi! Dėkojame už jūsų paramą didinant maisto skaidrumą pasaulyje.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">AŠ REMIU</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/lv.xlf
+++ b/web-components/xliff/lv.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/lv.xlf
+++ b/web-components/xliff/lv.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-review-translation" state-qualifier="leveraged-mt">Pagriezt attēlu pa labi</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Palīdziet mums informēt miljoniem patērētāju visā pasaulē par to, ko viņi ēd</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Jūsu ziedojumi finansē mūsu bezpeļņas asociācijas ikdienas darbību:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">atbalstīt sabiedrības veselības pētījumu attīstību.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Katrs ziedojums ir svarīgs! Mēs novērtējam jūsu atbalstu pārtikas pārredzamības veicināšanā pasaulē.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">ES ATBALSTU</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-review-translation" state-qualifier="leveraged-mt">grupas fotoattēlu ziedojums <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-review-translation" state-qualifier="leveraged-mt">Lūdzu, ziedojiet mūsu <x id="0" equiv-text="${this.currentYear}"/> līdzekļu vākšanas akcijai</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/mg.xlf
+++ b/web-components/xliff/mg.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/mg.xlf
+++ b/web-components/xliff/mg.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/mh.xlf
+++ b/web-components/xliff/mh.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/mh.xlf
+++ b/web-components/xliff/mh.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/mi.xlf
+++ b/web-components/xliff/mi.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/mi.xlf
+++ b/web-components/xliff/mi.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/mk.xlf
+++ b/web-components/xliff/mk.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/mk.xlf
+++ b/web-components/xliff/mk.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/mn.xlf
+++ b/web-components/xliff/mn.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/mn.xlf
+++ b/web-components/xliff/mn.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ms.xlf
+++ b/web-components/xliff/ms.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ms.xlf
+++ b/web-components/xliff/ms.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/mt.xlf
+++ b/web-components/xliff/mt.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/mt.xlf
+++ b/web-components/xliff/mt.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/my.xlf
+++ b/web-components/xliff/my.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/my.xlf
+++ b/web-components/xliff/my.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/na.xlf
+++ b/web-components/xliff/na.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/na.xlf
+++ b/web-components/xliff/na.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/nb.xlf
+++ b/web-components/xliff/nb.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/nb.xlf
+++ b/web-components/xliff/nb.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Roter bildet til høyre</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="translated">Hjelp oss å informere millioner av forbrukere over hele verden om hva de spiser</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="translated">Dine donasjoner finansierer den daglige driften av vår ideelle organisasjon:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="translated">støtte utviklingen av folkehelseforskning.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="translated">Hver donasjon teller! Vi setter pris på din støtte til å skape mer åpenhet om mat i verden.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">JEG STØTTER</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">gruppebildedonasjon <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Gi til vår <x id="0" equiv-text="${this.currentYear}"/> innsamlingsaksjon</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/nd.xlf
+++ b/web-components/xliff/nd.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/nd.xlf
+++ b/web-components/xliff/nd.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/ne.xlf
+++ b/web-components/xliff/ne.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ne.xlf
+++ b/web-components/xliff/ne.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/nl.xlf
+++ b/web-components/xliff/nl.xlf
@@ -998,6 +998,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/nl.xlf
+++ b/web-components/xliff/nl.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="final">Afbeelding naar rechts draaien</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Help ons miljoenen consumenten over de hele wereld te informeren over wat ze eten</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Met uw donaties financieren wij de dagelijkse activiteiten van onze non-profitorganisatie:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">de vooruitgang van onderzoek op het gebied van de volksgezondheid ondersteunen.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Elke donatie telt! Wij waarderen uw steun om meer voedseltransparantie in de wereld te brengen.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">IK STEUN</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934" approved="yes">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="final">groepsfoto donatie <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e" approved="yes">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="final">Doneer alstublieft aan onze <x id="0" equiv-text="${this.currentYear}"/> inzamelingsactie</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e" approved="yes">
         <source>Get It On Google Play</source>
@@ -1006,6 +994,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/nr.xlf
+++ b/web-components/xliff/nr.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -792,6 +780,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/nr.xlf
+++ b/web-components/xliff/nr.xlf
@@ -784,6 +784,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ny.xlf
+++ b/web-components/xliff/ny.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/ny.xlf
+++ b/web-components/xliff/ny.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/pap.xlf
+++ b/web-components/xliff/pap.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/pap.xlf
+++ b/web-components/xliff/pap.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/pl.xlf
+++ b/web-components/xliff/pl.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/pl.xlf
+++ b/web-components/xliff/pl.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Obróć obraz w prawo</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Pomóż nam informować miliony konsumentów na całym świecie o tym, co jedzą</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Twoje datki finansują codzienną działalność naszej organizacji non-profit:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">wspierają rozwój badań nad zdrowiem publicznym.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Każda darowizna się liczy! Doceniamy twoje wsparcie w zapewnianiu większej przejrzystości żywności na świecie.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">WSPIERAM</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-review-translation" state-qualifier="leveraged-mt">darowizna na grupowe zdjęcie <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-review-translation" state-qualifier="leveraged-mt">Prosimy o wsparcie naszej zbiórki <x id="0" equiv-text="${this.currentYear}"/></target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/prs.xlf
+++ b/web-components/xliff/prs.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/prs.xlf
+++ b/web-components/xliff/prs.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/ps.xlf
+++ b/web-components/xliff/ps.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/ps.xlf
+++ b/web-components/xliff/ps.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/pt.xlf
+++ b/web-components/xliff/pt.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Girar imagem para a direita</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Ajude-nos a informar a milhões de consumidores em todo o mundo sobre o que eles comem</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Suas doações financiam as operações diárias de nossa associação sem fins lucrativos:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">apoio ao avanço da investigação no domínio da saúde pública.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Cada doação é importante! Nós agradecemos seu apoio em trazer mais transparência alimentar no mundo.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">EU APOIO</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">doação de foto de grupo <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Por favor, contribua para a nossa campanha de angariação de fundos <x id="0" equiv-text="${this.currentYear}"/></target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1009,6 +997,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/pt.xlf
+++ b/web-components/xliff/pt.xlf
@@ -1001,6 +1001,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/qu.xlf
+++ b/web-components/xliff/qu.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/qu.xlf
+++ b/web-components/xliff/qu.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/rn.xlf
+++ b/web-components/xliff/rn.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/rn.xlf
+++ b/web-components/xliff/rn.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/ro.xlf
+++ b/web-components/xliff/ro.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ro.xlf
+++ b/web-components/xliff/ro.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Rotește imaginea la dreapta</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Ajutați-ne să informăm milioane de consumatori din întreaga lume despre ceea ce mănâncă</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Donațiile dumneavoastră finanțează operațiunile zilnice ale asociației noastre non-profit:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">susține avansarea cercetării în sănătate publică.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Fiecare donație contează! Apreciem sprijinul acordat în promovarea unei transparențe alimentare sporite în lume.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">EU SUSȚIN</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-review-translation" state-qualifier="leveraged-mt">donație fotografie de grup <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-review-translation" state-qualifier="leveraged-mt">Vă rugăm să donați pentru strângerea noastră de fonduri <x id="0" equiv-text="${this.currentYear}"/></target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ru.xlf
+++ b/web-components/xliff/ru.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ru.xlf
+++ b/web-components/xliff/ru.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Повернуть изображение вправо</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Помогите нам информировать миллионы потребителей по всему миру о том, что они едят</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Ваши пожертвования финансируют повседневную деятельность нашей некоммерческой ассоциации:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">поддерживать развитие исследований в области общественного здравоохранения.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Каждое пожертвование имеет значение! Мы ценим вашу поддержку в обеспечении большей прозрачности в отношении продовольствия в мире.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">Я ПОДДЕРЖИВАЮ</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">групповое фото пожертвования <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Пожалуйста, помогите нашему <x id="0" equiv-text="${this.currentYear}"/> Фонду</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/rw.xlf
+++ b/web-components/xliff/rw.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/rw.xlf
+++ b/web-components/xliff/rw.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/sg.xlf
+++ b/web-components/xliff/sg.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -792,6 +780,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/sg.xlf
+++ b/web-components/xliff/sg.xlf
@@ -784,6 +784,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/si.xlf
+++ b/web-components/xliff/si.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/si.xlf
+++ b/web-components/xliff/si.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/sk.xlf
+++ b/web-components/xliff/sk.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/sk.xlf
+++ b/web-components/xliff/sk.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Otočte obrázok doprava</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/sl.xlf
+++ b/web-components/xliff/sl.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/sl.xlf
+++ b/web-components/xliff/sl.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/sm.xlf
+++ b/web-components/xliff/sm.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/sm.xlf
+++ b/web-components/xliff/sm.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/sn.xlf
+++ b/web-components/xliff/sn.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/sn.xlf
+++ b/web-components/xliff/sn.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/so.xlf
+++ b/web-components/xliff/so.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/so.xlf
+++ b/web-components/xliff/so.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/sq.xlf
+++ b/web-components/xliff/sq.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-review-translation" state-qualifier="leveraged-mt">dhurim fotosh në grup <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-review-translation" state-qualifier="leveraged-mt">Ju lutemi të kontribuoni në <x id="0" equiv-text="${this.currentYear}"/> Mbledhjen tonë të fondeve</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/sq.xlf
+++ b/web-components/xliff/sq.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/sr.xlf
+++ b/web-components/xliff/sr.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/sr.xlf
+++ b/web-components/xliff/sr.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ss.xlf
+++ b/web-components/xliff/ss.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ss.xlf
+++ b/web-components/xliff/ss.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/st.xlf
+++ b/web-components/xliff/st.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/st.xlf
+++ b/web-components/xliff/st.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/sv.xlf
+++ b/web-components/xliff/sv.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/sv.xlf
+++ b/web-components/xliff/sv.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Rotera bilden åt höger</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Hjälp oss att informera miljontals konsumenter runt om i världen om vad de äter</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Dina donationer finansierar den dagliga verksamheten i vår ideella förening:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">stödja utvecklingen av folkhälsoforskning.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Varje donation räknas! Vi uppskattar ditt stöd för att skapa ytterligare transparens kring livsmedelsförsörjning i världen.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">JAG STÖDJER</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">gruppfotodonation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Ge ett bidrag till vår insamling <x id="0" equiv-text="${this.currentYear}"/></target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/sw.xlf
+++ b/web-components/xliff/sw.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/sw.xlf
+++ b/web-components/xliff/sw.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ta.xlf
+++ b/web-components/xliff/ta.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ta.xlf
+++ b/web-components/xliff/ta.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">உலகெங்கிலும் உள்ள மில்லியன் கணக்கான நுகர்வோருக்கு அவர்கள் என்ன சாப்பிடுகிறார்கள் என்பதைப் பற்றித் தெரிவிக்க எங்களுக்கு உதவுங்கள்</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">எங்கள் இலாப நோக்கற்ற சங்கத்தின் அன்றாட நடவடிக்கைகளுக்கு உங்கள் நன்கொடைகள் நிதியளிக்கின்றன:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">பொது சுகாதார ஆராய்ச்சியின் முன்னேற்றத்தை ஆதரிக்கவும்.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">ஒவ்வொரு நன்கொடையும் கணக்கிடப்படுகிறது! உலகில் மேலும் உணவு வெளிப்படைத்தன்மையை கொண்டு வர உங்கள் ஆதரவை நாங்கள் பாராட்டுகிறோம்.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">நான் ஆதரிக்கிறேன்</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/tg.xlf
+++ b/web-components/xliff/tg.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/tg.xlf
+++ b/web-components/xliff/tg.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/th.xlf
+++ b/web-components/xliff/th.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/th.xlf
+++ b/web-components/xliff/th.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">ช่วยเราให้ข้อมูลแก่ผู้บริโภคนับล้านทั่วโลกเกี่ยวกับสิ่งที่พวกเขากิน</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">เงินบริจาคของคุณช่วยสนับสนุนการดำเนินงานประจำวันของสมาคมไม่แสวงหาผลกำไรของเรา:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">สนับสนุนการพัฒนาการวิจัยด้านสาธารณสุข</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">ทุกการบริจาคมีความสำคัญ! เราขอขอบคุณสำหรับการสนับสนุนของคุณในการสร้างความโปร่งใสในด้านอาหารให้มากยิ่งขึ้นในโลก</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">ฉันสนับสนุน</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ti.xlf
+++ b/web-components/xliff/ti.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ti.xlf
+++ b/web-components/xliff/ti.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/tk.xlf
+++ b/web-components/xliff/tk.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/tk.xlf
+++ b/web-components/xliff/tk.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/tl.xlf
+++ b/web-components/xliff/tl.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/tl.xlf
+++ b/web-components/xliff/tl.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/tn.xlf
+++ b/web-components/xliff/tn.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/tn.xlf
+++ b/web-components/xliff/tn.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/to.xlf
+++ b/web-components/xliff/to.xlf
@@ -47,9 +47,6 @@
 <trans-unit id="s453188ea728f64da">
   <source>Add a nutrient</source>
 </trans-unit>
-<trans-unit id="s475b08749d0706ed">
-  <source>Help us inform millions of consumers around the world about what they eat</source>
-</trans-unit>
 <trans-unit id="sfc40ea3d5d5aa6f8">
   <source>Your donations fund the day-to-day operations of our non-profit association:</source>
 </trans-unit>
@@ -67,9 +64,6 @@
 </trans-unit>
 <trans-unit id="s100c4928cc74642a">
   <source>support the advancement of public health research.</source>
-</trans-unit>
-<trans-unit id="s6d7b6cdedaadfb6e">
-  <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
 </trans-unit>
 <trans-unit id="s6306a31415aea913">
   <source>I SUPPORT</source>
@@ -94,9 +88,6 @@
 </trans-unit>
 <trans-unit id="scbab4bd737ba7934">
   <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
-</trans-unit>
-<trans-unit id="s43df2e8395f6834e">
-  <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
 </trans-unit>
 <trans-unit id="h5d824b4954e56ea5">
   <source>Scan your <x id="0" equiv-text="&lt;span class=&quot;everyday&quot;&gt;"/>everyday<x id="1" equiv-text="&lt;/span&gt; &lt;span class=&quot;foods&quot;&gt;"/>foods<x id="2" equiv-text="&lt;/span&gt;"/></source>
@@ -754,6 +745,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
 </body>
 </file>

--- a/web-components/xliff/to.xlf
+++ b/web-components/xliff/to.xlf
@@ -746,6 +746,15 @@
 <trans-unit id="s6ffdc18b840acf30">
   <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
 </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-components/xliff/tr.xlf
+++ b/web-components/xliff/tr.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Resmi sağa döndür</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Dünya çapında milyonlarca tüketiciyi ne yedikleri konusunda bilgilendirmemize yardımcı olun</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Bağışlarınız, kâr amacı gütmeyen derneğimizin günlük faaliyetlerini finanse ediyor:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">halk sağlığı araştırmalarının ilerlemesini desteklemek.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Her bağış değerli! Dünyada gıda şeffaflığını daha da artırma yolundaki desteğiniz için teşekkür ederiz.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">DESTEKLİYORUM</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">grup fotoğrafı bağışı <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Lütfen <x id="0" equiv-text="${this.currentYear}"/> Bağış Toplama Kampanyamıza bağışta bulunun</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1008,6 +996,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/tr.xlf
+++ b/web-components/xliff/tr.xlf
@@ -1000,6 +1000,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ts.xlf
+++ b/web-components/xliff/ts.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ts.xlf
+++ b/web-components/xliff/ts.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/uk.xlf
+++ b/web-components/xliff/uk.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="translated">Повернути зображення праворуч</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Допоможіть нам інформувати мільйони споживачів по всьому світу про те, що вони їдять</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Ваші пожертви фінансують щоденні операції з нашої неприбуткової асоціації:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">підтримуємо розвиток досліджень громадського здоров'я.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Кожна пожертва має значення! Ми цінуємо вашу підтримку в забезпеченні подальшої прозорості харчових продуктів у світі.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">Я ПІДТРИМУЮ</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="translated">групове фото пожертвуваннь <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="translated">Будь ласка, долучіться до нашого <x id="0" equiv-text="${this.currentYear}"/> збору коштів</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/uk.xlf
+++ b/web-components/xliff/uk.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ur.xlf
+++ b/web-components/xliff/ur.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ur.xlf
+++ b/web-components/xliff/ur.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/uz.xlf
+++ b/web-components/xliff/uz.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/uz.xlf
+++ b/web-components/xliff/uz.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/ve.xlf
+++ b/web-components/xliff/ve.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/ve.xlf
+++ b/web-components/xliff/ve.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/vi.xlf
+++ b/web-components/xliff/vi.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/vi.xlf
+++ b/web-components/xliff/vi.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed" approved="yes">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="final">Hãy giúp chúng tôi cung cấp thông tin cho hàng triệu người tiêu dùng trên toàn thế giới về những gì họ ăn.</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8" approved="yes">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="final">Những khoản đóng góp của quý vị tài trợ cho các hoạt động hàng ngày của hiệp hội phi lợi nhuận của chúng tôi:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="final">Hỗ trợ sự phát triển của nghiên cứu y tế công cộng.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e" approved="yes">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="final">Mỗi đóng góp đều có ý nghĩa! Chúng tôi trân trọng sự hỗ trợ của bạn trong việc thúc đẩy tính minh bạch về thực phẩm trên toàn thế giới.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913" approved="yes">
         <source>I SUPPORT</source>
         <target state="final">TÔI ỦNG HỘ</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/xh.xlf
+++ b/web-components/xliff/xh.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/xh.xlf
+++ b/web-components/xliff/xh.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/zh.xlf
+++ b/web-components/xliff/zh.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/zh.xlf
+++ b/web-components/xliff/zh.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>

--- a/web-components/xliff/zu.xlf
+++ b/web-components/xliff/zu.xlf
@@ -66,10 +66,6 @@
         <source>Rotate image to the right</source>
         <target state="needs-translation">Rotate image to the right</target>
       </trans-unit>
-      <trans-unit id="s475b08749d0706ed">
-        <source>Help us inform millions of consumers around the world about what they eat</source>
-        <target state="needs-translation">Help us inform millions of consumers around the world about what they eat</target>
-      </trans-unit>
       <trans-unit id="sfc40ea3d5d5aa6f8">
         <source>Your donations fund the day-to-day operations of our non-profit association:</source>
         <target state="needs-translation">Your donations fund the day-to-day operations of our non-profit association:</target>
@@ -94,10 +90,6 @@
         <source>support the advancement of public health research.</source>
         <target state="needs-translation">support the advancement of public health research.</target>
       </trans-unit>
-      <trans-unit id="s6d7b6cdedaadfb6e">
-        <source>Each donation counts! We appreciate your support in bringing further food transparency in the world.</source>
-        <target state="needs-translation">Each donation counts! We appreciate your support in bringing further food transparency in the world.</target>
-      </trans-unit>
       <trans-unit id="s6306a31415aea913">
         <source>I SUPPORT</source>
         <target state="needs-translation">I SUPPORT</target>
@@ -105,10 +97,6 @@
       <trans-unit id="scbab4bd737ba7934">
         <source>group photo donation <x id="0" equiv-text="${this.currentYear}"/></source>
         <target state="needs-translation">group photo donation <x id="0" equiv-text="${this.currentYear}"/></target>
-      </trans-unit>
-      <trans-unit id="s43df2e8395f6834e">
-        <source>Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</source>
-        <target state="needs-translation">Please give to our <x id="0" equiv-text="${this.currentYear}"/> Fundraiser</target>
       </trans-unit>
       <trans-unit id="s000d98595e959c1e">
         <source>Get It On Google Play</source>
@@ -1010,6 +998,15 @@
 </trans-unit>
 <trans-unit id="sfb6c2292955d4453">
   <source>Fundraiser progress</source>
+</trans-unit>
+<trans-unit id="s8966e013dce8891f">
+  <source>We still need €120,000 to finish 2026!</source>
+</trans-unit>
+<trans-unit id="s4b2638408d2e3aa8">
+  <source>Become an Open Food Facts patron</source>
+</trans-unit>
+<trans-unit id="s12b36eaac15a1c74">
+  <source>If every visitor this month clicked on Donate and gave just 1€, we'd get over 8 times our yearly budget!</source>
 </trans-unit>
     </body>
   </file>

--- a/web-components/xliff/zu.xlf
+++ b/web-components/xliff/zu.xlf
@@ -1002,6 +1002,15 @@
         <source><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></source>
         <target state="needs-translation"><x id="0" equiv-text="${brands}"/> - <x id="1" equiv-text="${quantity}"/></target>
       </trans-unit>
+<trans-unit id="sb18dd702b5f51223">
+  <source><x id="0" equiv-text="${missing}"/> short</source>
+</trans-unit>
+<trans-unit id="s4e037fb4937e78d2">
+  <source>of <x id="0" equiv-text="${goal}"/></source>
+</trans-unit>
+<trans-unit id="sfb6c2292955d4453">
+  <source>Fundraiser progress</source>
+</trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
The tagline feed already publishes the fundraiser figures for the web (`raised`, `goal`, `currency` on the donation campaign, updated daily). The app renders them; on the web nothing read them.

![news feed before and after](https://raw.githubusercontent.com/UrbanFercec/openfoodfacts-webcomponents/assets/donation-meter-screenshots/news-feed-before-after.png)

- **Added:** a `donation-meter` element - raised, goal, percent, bar, amount still needed. It renders only when a campaign publishes all three fields; anything missing or malformed renders nothing.
- **Changed:** `news-feed` shows the meter for such a campaign. Since the live feed already carries the figures, **a page already embedding `<news-feed>` gains the meter with no change on its side** - the explorer settings page is the one I know of. That is the left/right pair above, both against the live feed. Say the word if you would rather it were opt-in; that is one attribute.
- **Added:** `donation-banner` takes an optional `news-url`. Without it the banner and its donate link are byte-identical to today.
- **Kept:** the guards from the app's meter, so the two surfaces cannot show different numbers.

![banner with the figures](https://raw.githubusercontent.com/UrbanFercec/openfoodfacts-webcomponents/assets/donation-meter-screenshots/banner-with-figures.png)

Notes you would otherwise have to ask about:

- No new dependency, and no host is hardcoded outside the stories - the feed url comes from the host, so this does not touch the CSP question in openfoodfacts-explorer#1780.
- The three new strings are English in every locale until Crowdin round-trips.
- `utm_content=meter` is added to the donate link only while a meter is actually showing figures, so the parameter counts what it claims to. A banner whose feed carries no campaign, fails to load, or publishes a figure that does not parse is left untagged.
- The app also shows "5 months left". `lit-localize` has no ICU plurals and a two-form English plural is wrong in Slovenian, Russian, Polish and Arabic, so it is left out rather than shipped wrong. It could come back as a date ("until 31 January 2027"), which needs no plural, if you want the urgency.
- The meter does not filter by country, language or app version the way `news-feed` does. Today's campaign sets none of those.
- The campaign icon shows as a placeholder in both screenshots: the feed points at an image that only exists under the android folder of the assets repo, so the web path 404s today. Unrelated to this change, happy to fix it there.
- `Intl.NumberFormat` is a first use in this repo; there was no in-repo number formatter.

**This branch carries the commit from #618**, cherry-picked with its authorship kept, so it does not need reapplying as a stacked PR. Whichever of the two merges first, the other should be closed rather than merged, or the 111 xliff files conflict.

- **Added:** `donate-url` / `donate-link`, so the embedding page passes its own donation URL - which is what openfoodfacts-server#14521 does. A root-relative path now works and resolves against the page.
- **Changed:** the fallback donation link and `utm_term` follow the UI language.
- **Changed:** the 2026 copy for the title, the hook and the financial callout, extracted into the xliff files.
- **Kept:** the `utm_content` condition above, which that commit predates.
- **Added:** a donate link that is not `http:` or `https:` falls back to the donation page. The link is rendered into an `href`, which lit does not sanitize, so `javascript:...//` would have run in the embedding page with the parameters appended after it commented out. Not an escalation on the site, where the template writes the attribute, but it is one for anything else embedding the published component.

Two questions on that commit, @teolemon:

- The new hook hardcodes a shortfall figure, and the meter beside it prints the live one from the feed. They disagree the moment the feed moves. Your copy, so your call.
- Does the server PR send `donate-url` or `donate-link`? Whichever it is, the other is unused public API from day one and could go.

Related: openfoodfacts-server#11719 (replace the site's donation banner with this component), openfoodfacts-server#5720.

